### PR TITLE
Add in-memory auth module and initial DB schema

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,59 @@
+const crypto = require('crypto');
+
+// In-memory store for users
+const users = new Map();
+
+function hashPassword(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+/**
+ * Sign up a new user.
+ * @param {string} email
+ * @param {string} password
+ * @param {string} nativeLanguage
+ * @param {string[]} learningLanguages
+ * @returns {{id:string,email:string,nativeLanguage:string,learningLanguages:string[]}}
+ */
+function signup(email, password, nativeLanguage, learningLanguages = []) {
+  if (users.has(email)) {
+    throw new Error('User already exists');
+  }
+  const id = crypto.randomUUID();
+  const passwordHash = hashPassword(password);
+  const user = {
+    id,
+    email,
+    passwordHash,
+    nativeLanguage,
+    learningLanguages: [...learningLanguages],
+  };
+  users.set(email, user);
+  return { id, email, nativeLanguage, learningLanguages: [...learningLanguages] };
+}
+
+/**
+ * Log in an existing user.
+ * @param {string} email
+ * @param {string} password
+ * @returns {{id:string,email:string,nativeLanguage:string,learningLanguages:string[]}}
+ */
+function login(email, password) {
+  const user = users.get(email);
+  if (!user) {
+    throw new Error('User not found');
+  }
+  const passwordHash = hashPassword(password);
+  if (user.passwordHash !== passwordHash) {
+    throw new Error('Invalid credentials');
+  }
+  const { id, nativeLanguage, learningLanguages } = user;
+  return { id, email, nativeLanguage, learningLanguages: [...learningLanguages] };
+}
+
+// Helper for tests to clear users
+function _clearUsers() {
+  users.clear();
+}
+
+module.exports = { signup, login, _clearUsers };

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,47 @@
+-- Database schema for Piru MVP
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    native_language TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE user_languages (
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    language_code TEXT NOT NULL,
+    PRIMARY KEY (user_id, language_code)
+);
+
+CREATE TABLE works (
+    id UUID PRIMARY KEY,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    title TEXT,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE vocab_entries (
+    id UUID PRIMARY KEY,
+    work_id UUID REFERENCES works(id) ON DELETE CASCADE,
+    word TEXT NOT NULL,
+    definition TEXT,
+    status TEXT DEFAULT 'new'
+);
+
+CREATE TABLE citations (
+    id UUID PRIMARY KEY,
+    vocab_entry_id UUID REFERENCES vocab_entries(id) ON DELETE CASCADE,
+    quote TEXT NOT NULL
+);
+
+CREATE TABLE reviews (
+    id UUID PRIMARY KEY,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    vocab_entry_id UUID REFERENCES vocab_entries(id) ON DELETE CASCADE,
+    scheduled_at DATE NOT NULL,
+    interval INTEGER NOT NULL,
+    repetitions INTEGER NOT NULL,
+    easiness REAL NOT NULL
+);

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,32 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('assert');
+const { signup, login, _clearUsers } = require('../src/auth');
+
+describe('Authentication', () => {
+  beforeEach(() => {
+    _clearUsers();
+  });
+
+  it('signs up a new user and stores languages', () => {
+    const user = signup('alice@example.com', 'secret', 'fr', ['en', 'es']);
+    assert.strictEqual(user.email, 'alice@example.com');
+    assert.strictEqual(user.nativeLanguage, 'fr');
+    assert.deepStrictEqual(user.learningLanguages, ['en', 'es']);
+  });
+
+  it('prevents duplicate signups', () => {
+    signup('bob@example.com', 'pass', 'fr', []);
+    assert.throws(() => signup('bob@example.com', 'pass', 'fr', []));
+  });
+
+  it('logs in an existing user', () => {
+    signup('carol@example.com', 'pwd', 'fr', ['en']);
+    const user = login('carol@example.com', 'pwd');
+    assert.strictEqual(user.email, 'carol@example.com');
+  });
+
+  it('rejects invalid credentials', () => {
+    signup('dave@example.com', 'pwd', 'fr', []);
+    assert.throws(() => login('dave@example.com', 'wrong'));
+  });
+});


### PR DESCRIPTION
## Summary
- implement basic signup/login with in-memory user store
- define SQL schema for users, works, vocabulary, and review tables
- add unit tests covering authentication flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1adfba7f4832bb23d077abffe1af5