### PR TITLE
Add dropdown for learning languages and native language placeholder

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -11,6 +11,7 @@ const resources = {
       password: 'Password',
       native_language: 'Native language',
       learning_languages: 'Learning languages (comma separated)',
+      select_language: 'Select language',
       your_works: 'Your Works',
       title: 'Title',
       author: 'Author',
@@ -29,6 +30,7 @@ const resources = {
       password: 'Mot de passe',
       native_language: 'Langue maternelle',
       learning_languages: 'Langues apprises (séparées par des virgules)',
+      select_language: 'Choisir une langue',
       your_works: 'Vos œuvres',
       title: 'Titre',
       author: 'Auteur',
@@ -57,6 +59,17 @@ function updateContent() {
 document.getElementById('signup-native').addEventListener('change', (e) => {
   i18next.changeLanguage(e.target.value);
   updateContent();
+});
+
+document.getElementById('learning-dropdown').addEventListener('change', (e) => {
+  const code = e.target.value;
+  const input = document.getElementById('signup-learning');
+  const languages = input.value ? input.value.split(',').map(l => l.trim()).filter(Boolean) : [];
+  if (!languages.includes(code)) {
+    languages.push(code);
+    input.value = languages.join(', ');
+  }
+  e.target.selectedIndex = 0;
 });
 
 document.getElementById('login-form').addEventListener('submit', async (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -23,9 +23,17 @@
       <form id="signup-form">
         <input type="email" id="signup-email" data-i18n-placeholder="email" placeholder="Email" required />
         <input type="password" id="signup-password" data-i18n-placeholder="password" placeholder="Password" required />
-        <label for="signup-native" data-i18n="native_language">Native language</label>
         <select id="signup-native">
+          <option value="" disabled selected data-i18n="native_language">Native language</option>
           <option value="fr">🇫🇷 Français</option>
+        </select>
+        <select id="learning-dropdown">
+          <option value="" disabled selected data-i18n="select_language">Select language</option>
+          <option value="en">🇬🇧 English</option>
+          <option value="es">🇪🇸 Español</option>
+          <option value="fr">🇫🇷 Français</option>
+          <option value="de">🇩🇪 Deutsch</option>
+          <option value="it">🇮🇹 Italiano</option>
         </select>
         <input type="text" id="signup-learning" data-i18n-placeholder="learning_languages" placeholder="Learning languages (comma separated)" required />
         <button type="submit" data-i18n="sign_up">Sign Up</button>


### PR DESCRIPTION
## Summary
- remove native language label and show placeholder option before "Français"
- add selectable dropdown of common learning languages with flags to populate the input field
- add translations and event handler for new language dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c7e33394832b8f017aa0aaf00872