### PR TITLE
Add staging environment with test account

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Initialize the local SQLite database (creates tables if they don't exist):
 npm run init-db
 ```
 
+### Staging environment
+
+Run a local staging server with a pre-created test account:
+
+```bash
+npm run init-db:staging   # optional, creates a separate staging database
+npm run start:staging
+```
+
+The staging server listens on port 4000 and exposes the account `staging@example.com` with password `staging123`.
+
 ### Algorithms
 
 The `src/sm2.js` module implements the SM-2 spaced repetition algorithm used

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "node --test",
     "init-db": "node scripts/initDb.js",
-    "start": "node src/server.js"
+    "init-db:staging": "NODE_ENV=staging node scripts/initDb.js",
+    "start": "node src/server.js",
+    "start:staging": "NODE_ENV=staging PORT=4000 node src/server.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -3,7 +3,8 @@ const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 
 // Path to SQLite database file
-const dbPath = path.join(__dirname, '..', 'piru.sqlite');
+const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
+const dbPath = path.join(__dirname, '..', dbFile);
 // Path to schema SQL file
 const schemaPath = path.join(__dirname, '..', 'src', 'db', 'schema.sql');
 

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,16 @@ app.use(express.json());
 app.use(express.static(path.join(__dirname, '..', 'public')));
 app.use('/lib/i18next', express.static(path.join(__dirname, '..', 'node_modules', 'i18next', 'dist')));
 
+if (process.env.NODE_ENV === 'staging') {
+  try {
+    signup('staging@example.com', 'staging123', 'en', ['fr']);
+    // eslint-disable-next-line no-console
+    console.log('Staging user ready: staging@example.com / staging123');
+  } catch (err) {
+    // ignore if user already exists
+  }
+}
+
 app.post('/auth/signup', (req, res) => {
   const { email, password, nativeLanguage, learningLanguages } = req.body;
   try {


### PR DESCRIPTION
## Summary
- add staging startup script with dedicated environment variables
- auto-create staging test user for easy login
- document and support separate staging database

## Testing
- `npm test`
- `npm run start:staging`

------
https://chatgpt.com/codex/tasks/task_e_68b1e53669e8832bae39b835b570620c