### PR TITLE
feat: dynamic native language selection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -41,7 +41,20 @@ const resources = {
   }
 };
 
-const defaultLang = document.getElementById('signup-native').value || 'en';
+const nativeLanguages = [
+  { code: 'fr', label: '🇫🇷 Français' },
+  { code: 'en', label: '🇬🇧 English' }
+];
+
+const nativeSelect = document.getElementById('signup-native');
+nativeLanguages.forEach(({ code, label }) => {
+  const option = document.createElement('option');
+  option.value = code;
+  option.textContent = label;
+  nativeSelect.appendChild(option);
+});
+
+const defaultLang = nativeSelect.value || 'en';
 i18next.init({ lng: defaultLang, resources }).then(() => {
   updateContent();
 });

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,6 @@
         <input type="password" id="signup-password" data-i18n-placeholder="password" placeholder="Password" required />
         <select id="signup-native">
           <option value="" disabled selected data-i18n="native_language">Native language</option>
-          <option value="fr">🇫🇷 Français</option>
         </select>
         <select id="learning-dropdown">
           <option value="" disabled selected data-i18n="select_language">Select language</option>


### PR DESCRIPTION
## Summary
- populate native language dropdown dynamically and include English and French options
- keep "Native language" placeholder selected by default on signup form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e56d5b50832b849f8d88b9ffdb4b