### PR TITLE
feat: allow multiple learning language selections

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10,7 +10,7 @@ const resources = {
       email: 'Email',
       password: 'Password',
       native_language: 'Native language',
-      learning_languages: 'Learning languages (comma separated)',
+      learning_languages: 'Learning languages',
       select_language: 'Select language',
       your_works: 'Your Works',
       title: 'Title',
@@ -29,7 +29,7 @@ const resources = {
       email: 'Email',
       password: 'Mot de passe',
       native_language: 'Langue maternelle',
-      learning_languages: 'Langues apprises (séparées par des virgules)',
+      learning_languages: 'Langues apprises',
       select_language: 'Choisir une langue',
       your_works: 'Vos œuvres',
       title: 'Titre',
@@ -61,17 +61,6 @@ document.getElementById('signup-native').addEventListener('change', (e) => {
   updateContent();
 });
 
-document.getElementById('learning-dropdown').addEventListener('change', (e) => {
-  const code = e.target.value;
-  const input = document.getElementById('signup-learning');
-  const languages = input.value ? input.value.split(',').map(l => l.trim()).filter(Boolean) : [];
-  if (!languages.includes(code)) {
-    languages.push(code);
-    input.value = languages.join(', ');
-  }
-  e.target.selectedIndex = 0;
-});
-
 document.getElementById('login-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const email = document.getElementById('login-email').value;
@@ -99,7 +88,7 @@ document.getElementById('signup-form').addEventListener('submit', async (e) => {
   const email = document.getElementById('signup-email').value;
   const password = document.getElementById('signup-password').value;
   const nativeLanguage = document.getElementById('signup-native').value;
-  const learningLanguages = document.getElementById('signup-learning').value.split(',').map(l => l.trim());
+  const learningLanguages = Array.from(document.getElementById('signup-learning').selectedOptions).map(o => o.value);
   const res = await fetch('/auth/signup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/public/index.html
+++ b/public/index.html
@@ -27,15 +27,14 @@
           <option value="" disabled selected data-i18n="native_language">Native language</option>
           <option value="fr">🇫🇷 Français</option>
         </select>
-        <select id="learning-dropdown">
-          <option value="" disabled selected data-i18n="select_language">Select language</option>
+        <label for="signup-learning" data-i18n="learning_languages">Learning languages</label>
+        <select id="signup-learning" multiple>
           <option value="en">🇬🇧 English</option>
           <option value="es">🇪🇸 Español</option>
           <option value="fr">🇫🇷 Français</option>
           <option value="de">🇩🇪 Deutsch</option>
           <option value="it">🇮🇹 Italiano</option>
         </select>
-        <input type="text" id="signup-learning" data-i18n-placeholder="learning_languages" placeholder="Learning languages (comma separated)" required />
         <button type="submit" data-i18n="sign_up">Sign Up</button>
       </form>
     </section>


### PR DESCRIPTION
## Summary
- replace single language dropdown and text field with a multi-select dropdown
- adjust translations and signup logic to handle multiple language selections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e5a7074c832bbc3ff64fbf9e714d