### PR TITLE
Require explicit native language selection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -54,6 +54,9 @@ nativeLanguages.forEach(({ code, label }) => {
   nativeSelect.appendChild(option);
 });
 
+// Ensure the placeholder option remains selected by default
+nativeSelect.value = '';
+
 const defaultLang = nativeSelect.value || 'en';
 i18next.init({ lng: defaultLang, resources }).then(() => {
   updateContent();

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       <form id="signup-form">
         <input type="email" id="signup-email" data-i18n-placeholder="email" placeholder="Email" required />
         <input type="password" id="signup-password" data-i18n-placeholder="password" placeholder="Password" required />
-        <select id="signup-native">
+        <select id="signup-native" required>
           <option value="" disabled selected data-i18n="native_language">Native language</option>
         </select>
         <label for="signup-learning" data-i18n="learning_languages">Learning languages</label>


### PR DESCRIPTION
## Summary
- Ensure native language dropdown defaults to placeholder instead of first option
- Make native language selection mandatory during sign up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b281d9eda4832bb42e529245e7a5c4