### PR TITLE
Require selecting learning languages during signup

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -101,7 +101,13 @@ document.getElementById('signup-form').addEventListener('submit', async (e) => {
   const email = document.getElementById('signup-email').value;
   const password = document.getElementById('signup-password').value;
   const nativeLanguage = document.getElementById('signup-native').value;
-  const learningLanguages = Array.from(document.getElementById('signup-learning').selectedOptions).map(o => o.value);
+  const learningLanguages = Array.from(document.getElementById('signup-learning').selectedOptions)
+    .map(o => o.value)
+    .filter(Boolean);
+  if (learningLanguages.length === 0) {
+    alert(i18next.t('select_language'));
+    return;
+  }
   const res = await fetch('/auth/signup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/public/index.html
+++ b/public/index.html
@@ -26,8 +26,8 @@
         <select id="signup-native">
           <option value="" disabled selected data-i18n="native_language">Native language</option>
         </select>
-        <label for="signup-learning" data-i18n="learning_languages">Learning languages</label>
         <select id="signup-learning" multiple>
+          <option value="" disabled selected data-i18n="learning_languages">Learning languages</option>
           <option value="en">🇬🇧 English</option>
           <option value="es">🇪🇸 Español</option>
           <option value="fr">🇫🇷 Français</option>

--- a/src/auth.js
+++ b/src/auth.js
@@ -16,6 +16,9 @@ function hashPassword(password) {
  * @returns {{id:string,email:string,nativeLanguage:string,learningLanguages:string[]}}
  */
 function signup(email, password, nativeLanguage, learningLanguages = []) {
+  if (!Array.isArray(learningLanguages) || learningLanguages.length === 0) {
+    throw new Error('At least one learning language is required');
+  }
   if (users.has(email)) {
     throw new Error('User already exists');
   }

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -15,8 +15,8 @@ describe('Authentication', () => {
   });
 
   it('prevents duplicate signups', () => {
-    signup('bob@example.com', 'pass', 'fr', []);
-    assert.throws(() => signup('bob@example.com', 'pass', 'fr', []));
+    signup('bob@example.com', 'pass', 'fr', ['en']);
+    assert.throws(() => signup('bob@example.com', 'pass', 'fr', ['en']));
   });
 
   it('logs in an existing user', () => {
@@ -26,7 +26,11 @@ describe('Authentication', () => {
   });
 
   it('rejects invalid credentials', () => {
-    signup('dave@example.com', 'pwd', 'fr', []);
+    signup('dave@example.com', 'pwd', 'fr', ['en']);
     assert.throws(() => login('dave@example.com', 'wrong'));
+  });
+
+  it('requires at least one learning language', () => {
+    assert.throws(() => signup('eve@example.com', 'pwd', 'fr', []));
   });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -24,17 +24,17 @@ describe('Auth API', () => {
   it('prevents duplicate signup', async () => {
     await request(app)
       .post('/auth/signup')
-      .send({ email: 'dupe@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: [] });
+      .send({ email: 'dupe@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: ['en'] });
     const res = await request(app)
       .post('/auth/signup')
-      .send({ email: 'dupe@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: [] });
+      .send({ email: 'dupe@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: ['en'] });
     assert.strictEqual(res.status, 400);
   });
 
   it('logs in existing user', async () => {
     await request(app)
       .post('/auth/signup')
-      .send({ email: 'login@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: [] });
+      .send({ email: 'login@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: ['en'] });
     const res = await request(app)
       .post('/auth/login')
       .send({ email: 'login@example.com', password: 'secret' });
@@ -45,11 +45,18 @@ describe('Auth API', () => {
   it('rejects invalid login', async () => {
     await request(app)
       .post('/auth/signup')
-      .send({ email: 'badlogin@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: [] });
+      .send({ email: 'badlogin@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: ['en'] });
     const res = await request(app)
       .post('/auth/login')
       .send({ email: 'badlogin@example.com', password: 'wrong' });
     assert.strictEqual(res.status, 401);
+  });
+  
+  it('requires at least one learning language', async () => {
+    const res = await request(app)
+      .post('/auth/signup')
+      .send({ email: 'nolanguage@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: [] });
+    assert.strictEqual(res.status, 400);
   });
 });
 


### PR DESCRIPTION
## Summary
- Move "Learning languages" into the signup dropdown as a disabled default option
- Block signup until the user chooses at least one learning language
- Enforce learning language requirement on the server and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2826b4e3c832bb9e93fbad84abdd8