### PR TITLE
Restrict signup to French native language

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -17,7 +17,8 @@ const resources = {
       author: 'Author',
       content: 'Content',
       add_work: 'Add Work',
-      account_created: 'Account created. You can now log in.'
+      account_created: 'Account created. You can now log in.',
+      language_unavailable: 'Language not available'
     }
   },
   fr: {
@@ -36,7 +37,8 @@ const resources = {
       author: 'Auteur',
       content: 'Contenu',
       add_work: 'Ajouter une œuvre',
-      account_created: 'Compte créé. Vous pouvez maintenant vous connecter.'
+      account_created: 'Compte créé. Vous pouvez maintenant vous connecter.',
+      language_unavailable: "Cette langue n'est pas disponible"
     }
   }
 };
@@ -47,6 +49,8 @@ const nativeLanguages = [
 ];
 
 const nativeSelect = document.getElementById('signup-native');
+const signupButton = document.querySelector('#signup-form button[type="submit"]');
+const languageError = document.getElementById('signup-language-error');
 nativeLanguages.forEach(({ code, label }) => {
   const option = document.createElement('option');
   option.value = code;
@@ -56,6 +60,7 @@ nativeLanguages.forEach(({ code, label }) => {
 
 // Ensure the placeholder option remains selected by default
 nativeSelect.value = '';
+signupButton.disabled = true;
 
 const defaultLang = nativeSelect.value || 'en';
 i18next.init({ lng: defaultLang, resources }).then(() => {
@@ -73,8 +78,16 @@ function updateContent() {
 }
 
 document.getElementById('signup-native').addEventListener('change', (e) => {
-  i18next.changeLanguage(e.target.value);
+  const lang = e.target.value;
+  i18next.changeLanguage(lang);
   updateContent();
+  if (lang !== 'fr') {
+    signupButton.disabled = true;
+    languageError.classList.remove('hidden');
+  } else {
+    signupButton.disabled = false;
+    languageError.classList.add('hidden');
+  }
 });
 
 document.getElementById('login-form').addEventListener('submit', async (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
         <select id="signup-native" required>
           <option value="" disabled selected data-i18n="native_language">Native language</option>
         </select>
+        <p id="signup-language-error" class="hidden" data-i18n="language_unavailable"></p>
         <label for="signup-learning" data-i18n="learning_languages">Learning languages</label>
         <select id="signup-learning" multiple>
           <option value="en">🇬🇧 English</option>

--- a/src/auth.js
+++ b/src/auth.js
@@ -19,6 +19,9 @@ function signup(email, password, nativeLanguage, learningLanguages = []) {
   if (users.has(email)) {
     throw new Error('User already exists');
   }
+  if (nativeLanguage !== 'fr') {
+    throw new Error('Native language not available');
+  }
   const id = crypto.randomUUID();
   const passwordHash = hashPassword(password);
   const user = {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -19,6 +19,10 @@ describe('Authentication', () => {
     assert.throws(() => signup('bob@example.com', 'pass', 'fr', []));
   });
 
+  it('rejects non-French native languages', () => {
+    assert.throws(() => signup('eve@example.com', 'pwd', 'en', []));
+  });
+
   it('logs in an existing user', () => {
     signup('carol@example.com', 'pwd', 'fr', ['en']);
     const user = login('carol@example.com', 'pwd');

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -21,6 +21,13 @@ describe('Auth API', () => {
     assert.deepStrictEqual(res.body.learningLanguages, ['en']);
   });
 
+  it('rejects signup with non-French native language', async () => {
+    const res = await request(app)
+      .post('/auth/signup')
+      .send({ email: 'nofr@example.com', password: 'secret', nativeLanguage: 'en', learningLanguages: [] });
+    assert.strictEqual(res.status, 400);
+  });
+
   it('prevents duplicate signup', async () => {
     await request(app)
       .post('/auth/signup')


### PR DESCRIPTION
## Summary
- disable signup when native language isn't French and show a helpful message
- enforce French-only signup on the server
- test that non-French signups are rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2834a7340832b993a68eb9f303932