### PR TITLE
Use single dropdown for learning language

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10,7 +10,7 @@ const resources = {
       email: 'Email',
       password: 'Password',
       native_language: 'Native language',
-      learning_languages: 'Learning languages',
+      learning_language: 'Learning language',
       select_language: 'Select language',
       your_works: 'Your Works',
       title: 'Title',
@@ -29,7 +29,7 @@ const resources = {
       email: 'Email',
       password: 'Mot de passe',
       native_language: 'Langue maternelle',
-      learning_languages: 'Langues apprises',
+      learning_language: 'Langue apprise',
       select_language: 'Choisir une langue',
       your_works: 'Vos œuvres',
       title: 'Titre',
@@ -46,6 +46,14 @@ const nativeLanguages = [
   { code: 'en', label: '🇬🇧 English' }
 ];
 
+const learningLanguages = [
+  { code: 'en', label: '🇬🇧 English' },
+  { code: 'es', label: '🇪🇸 Español' },
+  { code: 'fr', label: '🇫🇷 Français' },
+  { code: 'de', label: '🇩🇪 Deutsch' },
+  { code: 'it', label: '🇮🇹 Italiano' }
+];
+
 const nativeSelect = document.getElementById('signup-native');
 nativeLanguages.forEach(({ code, label }) => {
   const option = document.createElement('option');
@@ -54,8 +62,17 @@ nativeLanguages.forEach(({ code, label }) => {
   nativeSelect.appendChild(option);
 });
 
+const learningSelect = document.getElementById('signup-learning');
+learningLanguages.forEach(({ code, label }) => {
+  const option = document.createElement('option');
+  option.value = code;
+  option.textContent = label;
+  learningSelect.appendChild(option);
+});
+
 // Ensure the placeholder option remains selected by default
 nativeSelect.value = '';
+learningSelect.value = '';
 
 const defaultLang = nativeSelect.value || 'en';
 i18next.init({ lng: defaultLang, resources }).then(() => {
@@ -104,17 +121,15 @@ document.getElementById('signup-form').addEventListener('submit', async (e) => {
   const email = document.getElementById('signup-email').value;
   const password = document.getElementById('signup-password').value;
   const nativeLanguage = document.getElementById('signup-native').value;
-  const learningLanguages = Array.from(document.getElementById('signup-learning').selectedOptions)
-    .map(o => o.value)
-    .filter(Boolean);
-  if (learningLanguages.length === 0) {
+  const learningLanguage = document.getElementById('signup-learning').value;
+  if (!learningLanguage) {
     alert(i18next.t('select_language'));
     return;
   }
   const res = await fetch('/auth/signup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password, nativeLanguage, learningLanguages })
+    body: JSON.stringify({ email, password, nativeLanguage, learningLanguages: [learningLanguage] })
   });
   const data = await res.json();
   if (res.ok) {

--- a/public/index.html
+++ b/public/index.html
@@ -26,13 +26,8 @@
         <select id="signup-native" required>
           <option value="" disabled selected data-i18n="native_language">Native language</option>
         </select>
-        <select id="signup-learning" multiple>
-          <option value="" disabled selected data-i18n="learning_languages">Learning languages</option>
-          <option value="en">🇬🇧 English</option>
-          <option value="es">🇪🇸 Español</option>
-          <option value="fr">🇫🇷 Français</option>
-          <option value="de">🇩🇪 Deutsch</option>
-          <option value="it">🇮🇹 Italiano</option>
+        <select id="signup-learning" required>
+          <option value="" disabled selected data-i18n="learning_language">Learning language</option>
         </select>
         <button type="submit" data-i18n="sign_up">Sign Up</button>
       </form>


### PR DESCRIPTION
## Summary
- Replace learning-language multi-select with a single-selection dropdown
- Populate learning language options programmatically and update translations
- Adjust signup handler to send one selected learning language

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b283b6dff4832b81378c6269f9b42e