### PR TITLE
feat: add statistics overview

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -119,11 +119,8 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
   const data = await res.json();
   if (res.ok) {
     userId = data.id;
-    i18next.changeLanguage(data.nativeLanguage);
-    updateContent();
-    document.getElementById('auth').classList.add('hidden');
-    document.getElementById('works').classList.remove('hidden');
-    loadWorks();
+    localStorage.setItem('userId', userId);
+    window.location.href = 'stats.html';
   } else {
     alert(data.error);
   }

--- a/public/stats.html
+++ b/public/stats.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Piru - Stats</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1>Statistics</h1>
+    <p>Total words encountered: <span id="total-words">0</span></p>
+    <p>Mastered words: <span id="mastered-words">0</span></p>
+  </main>
+  <script src="stats.js"></script>
+</body>
+</html>

--- a/public/stats.js
+++ b/public/stats.js
@@ -1,0 +1,15 @@
+async function loadStats() {
+  const userId = localStorage.getItem('userId');
+  if (!userId) {
+    window.location.href = '/';
+    return;
+  }
+  const res = await fetch(`/stats/overview?userId=${userId}`);
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('total-words').textContent = data.totalWords;
+    document.getElementById('mastered-words').textContent = data.masteredWords;
+  }
+}
+
+loadStats();

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const { signup, login } = require('./auth');
 const { addWork, listWorks } = require('./works');
+const { getOverview } = require('./stats');
 
 const app = express();
 app.use(express.json());
@@ -55,6 +56,16 @@ app.get('/works', (req, res) => {
   }
   const works = listWorks(userId);
   res.json(works);
+});
+
+// Stats endpoints
+app.get('/stats/overview', (req, res) => {
+  const { userId } = req.query;
+  if (!userId) {
+    return res.status(400).json({ error: 'Missing userId' });
+  }
+  const overview = getOverview(userId);
+  res.json(overview);
 });
 
 if (require.main === module) {

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,0 +1,21 @@
+const { listWorks } = require('./works');
+
+/**
+ * Compute overview statistics for a user.
+ * @param {string} userId
+ * @returns {{totalWords:number, masteredWords:number}}
+ */
+function getOverview(userId) {
+  const works = listWorks(userId);
+  let totalWords = 0;
+  let masteredWords = 0;
+
+  works.forEach((work) => {
+    totalWords += work.vocab.length;
+    masteredWords += work.vocab.filter((v) => v.status === 'mastered').length;
+  });
+
+  return { totalWords, masteredWords };
+}
+
+module.exports = { getOverview };

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -1,0 +1,34 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('assert');
+const request = require('supertest');
+const app = require('../src/server');
+const { addWork, _clearWorks } = require('../src/works');
+const { getOverview } = require('../src/stats');
+
+describe('Stats overview', () => {
+  beforeEach(() => {
+    _clearWorks();
+  });
+
+  it('computes totals for a user', () => {
+    const content = 'extraordinary narratives with enigmatic characters appear';
+    addWork('user1', 'Sample', 'Author', content);
+    const stats = getOverview('user1');
+    assert.strictEqual(stats.totalWords, 4);
+    assert.strictEqual(stats.masteredWords, 0);
+  });
+
+  it('serves overview via API', async () => {
+    const userId = 'apiUser';
+    const content = 'magnificent creatures roam';
+    await request(app)
+      .post('/works')
+      .send({ userId, title: 'T', author: 'A', content });
+    const res = await request(app)
+      .get('/stats/overview')
+      .query({ userId });
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.totalWords, 2);
+    assert.strictEqual(res.body.masteredWords, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add stats module and API endpoint for aggregated vocabulary counts
- show user statistics after login and redirect to dedicated page
- cover statistics logic with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28a4cd03c832bae3ca00b0a1e0bb5