### PR TITLE
Fix staging signup language configuration

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,7 @@ app.use('/lib/i18next', express.static(path.join(__dirname, '..', 'node_modules'
 
 if (process.env.NODE_ENV === 'staging') {
   try {
-    signup('staging@example.com', 'staging123', 'en', ['fr']);
+    signup('staging@example.com', 'staging123', 'fr', ['en']);
     // eslint-disable-next-line no-console
     console.log('Staging user ready: staging@example.com / staging123');
   } catch (err) {


### PR DESCRIPTION
## Summary
- Set the staging signup to use French as native language and English as learning language

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28ae47984832b96e652dd1c3d2cd3