### PR TITLE
Ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
## Summary
- prevent macOS Finder metadata files from being tracked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b291fa1304832b89f2729d27e71b8e