### PR TITLE
fix: ensure static assets served

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -6,8 +6,11 @@ const { getOverview } = require('./stats');
 
 const app = express();
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '..', 'public')));
-app.use('/lib/i18next', express.static(path.join(__dirname, '..', 'node_modules', 'i18next', 'dist')));
+app.use(express.static(path.resolve(__dirname, '..', 'public')));
+app.use(
+  '/lib/i18next',
+  express.static(path.join(__dirname, '..', 'node_modules', 'i18next', 'dist'))
+);
 
 if (process.env.NODE_ENV === 'staging') {
   try {


### PR DESCRIPTION
## Summary
- serve static assets using an absolute path so favicon is found

## Testing
- `npm test`
- `node -e "const request=require('supertest');const app=require('./src/server');request(app).get('/favicon.ico').then(res=>{console.log('status',res.status);console.log('headers',res.headers['content-type']);}).catch(err=>{console.error('error',err.status,err.response&&err.response.text);});"`


------
https://chatgpt.com/codex/tasks/task_e_68b293f650c0832bbe8a258f53c9c8df