### PR TITLE
Add vocabulary extraction and flashcard review

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Piru - Flashcards</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1>Vocabulary Review</h1>
+    <section id="input-section">
+      <textarea id="input-text" placeholder="Paste text here"></textarea>
+      <button id="extract-btn">Extract Vocabulary</button>
+    </section>
+    <section id="flashcard-section" class="hidden">
+      <div id="word"></div>
+      <div id="definition" class="hidden"></div>
+      <button id="show-btn">Show Definition</button>
+      <div id="review-buttons" class="hidden">
+        <button data-quality="1">Again</button>
+        <button data-quality="4">Good</button>
+      </div>
+    </section>
+  </main>
+  <script src="flashcards.js"></script>
+</body>
+</html>

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -1,0 +1,63 @@
+let currentWord = null;
+
+async function extractVocabulary() {
+  const text = document.getElementById('input-text').value;
+  const userId = localStorage.getItem('userId');
+  if (!userId) {
+    window.location.href = '/';
+    return;
+  }
+  if (!text.trim()) return;
+  await fetch('/vocab/extract', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, text })
+  });
+  document.getElementById('input-text').value = '';
+  loadNext();
+}
+
+async function loadNext() {
+  const userId = localStorage.getItem('userId');
+  if (!userId) {
+    window.location.href = '/';
+    return;
+  }
+  const res = await fetch(`/vocab/next?userId=${userId}`);
+  if (res.status === 200) {
+    currentWord = await res.json();
+    document.getElementById('word').textContent = currentWord.word;
+    document.getElementById('definition').textContent = currentWord.definition;
+    document.getElementById('flashcard-section').classList.remove('hidden');
+    document.getElementById('definition').classList.add('hidden');
+    document.getElementById('review-buttons').classList.add('hidden');
+    document.getElementById('show-btn').classList.remove('hidden');
+  } else {
+    document.getElementById('flashcard-section').classList.add('hidden');
+  }
+}
+
+function showDefinition() {
+  document.getElementById('definition').classList.remove('hidden');
+  document.getElementById('review-buttons').classList.remove('hidden');
+  document.getElementById('show-btn').classList.add('hidden');
+}
+
+async function review(quality) {
+  const userId = localStorage.getItem('userId');
+  if (!currentWord) return;
+  await fetch('/vocab/review', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, wordId: currentWord.id, quality })
+  });
+  loadNext();
+}
+
+document.getElementById('extract-btn').addEventListener('click', extractVocabulary);
+document.getElementById('show-btn').addEventListener('click', showDefinition);
+document.querySelectorAll('#review-buttons button').forEach((btn) => {
+  btn.addEventListener('click', () => review(Number(btn.dataset.quality)));
+});
+
+loadNext();

--- a/public/stats.html
+++ b/public/stats.html
@@ -11,6 +11,7 @@
     <h1>Statistics</h1>
     <p>Total words encountered: <span id="total-words">0</span></p>
     <p>Mastered words: <span id="mastered-words">0</span></p>
+    <p><a href="flashcards.html">Review Vocabulary</a></p>
   </main>
   <script src="stats.js"></script>
 </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -23,3 +23,18 @@ form {
 .hidden {
   display: none;
 }
+
+#input-section textarea {
+  width: 100%;
+  height: 100px;
+}
+
+#flashcard-section {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+#word {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- Extract difficult words from user text and store per-user vocabulary for spaced repetition.
- Provide flashcard review page with automatic vocabulary extraction and SM-2 scheduling.
- Expose API endpoints for vocabulary extraction, next-card retrieval, and review updates.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b29954d8e0832ba30c374d31dbdc4d