### PR TITLE
Apply new branding with colors, fonts, and parrot logo

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -7,8 +7,12 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <header>
+    <img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" />
+    <h1>Piru</h1>
+  </header>
   <main>
-    <h1>Vocabulary Review</h1>
+    <h2>Vocabulary Review</h2>
     <section id="input-section">
       <textarea id="input-text" placeholder="Paste text here"></textarea>
       <button id="extract-btn">Extract Vocabulary</button>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <header>
+    <img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" />
     <h1 data-i18n="site_name">Piru</h1>
     <p data-i18n="tagline">Consume media in foreign languages.</p>
   </header>

--- a/public/stats.html
+++ b/public/stats.html
@@ -7,8 +7,12 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <header>
+    <img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" />
+    <h1>Piru</h1>
+  </header>
   <main>
-    <h1>Statistics</h1>
+    <h2>Statistics</h2>
     <p>Total words encountered: <span id="total-words">0</span></p>
     <p>Mastered words: <span id="mastered-words">0</span></p>
     <p><a href="flashcards.html">Review Vocabulary</a></p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,16 +1,50 @@
+@import url('https://fonts.cdnfonts.com/css/big-font');
+@import url('https://fonts.cdnfonts.com/css/gotham');
+
+:root {
+  --color-yellow: #fdd301;
+  --color-blue: #46c7f4;
+  --color-light: #edf2f2;
+  --color-gray: #6d7070;
+  --color-dark: #221f1f;
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Gotham', sans-serif;
+  background-color: var(--color-light);
+  color: var(--color-dark);
   margin: 0;
-  padding: 1rem;
+  padding: 0;
 }
 
 header {
+  background-color: var(--color-blue);
   text-align: center;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(34, 31, 31, 0.1);
+}
+
+header h1 {
+  font-family: 'BigFont', sans-serif;
+  margin: 0.5rem 0 0;
+}
+
+header p {
+  margin: 0;
+}
+
+.logo {
+  width: 80px;
+  height: auto;
 }
 
 main {
   max-width: 600px;
-  margin: 0 auto;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(34, 31, 31, 0.1);
 }
 
 form {
@@ -18,6 +52,28 @@ form {
   flex-direction: column;
   gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+input,
+textarea,
+select {
+  padding: 0.5rem;
+  border: 1px solid var(--color-gray);
+  border-radius: 4px;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background-color: var(--color-yellow);
+  color: var(--color-dark);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: var(--color-blue);
+  color: var(--color-light);
 }
 
 .hidden {
@@ -37,4 +93,5 @@ form {
 #word {
   font-size: 2rem;
   margin-bottom: 1rem;
+  font-family: 'BigFont', sans-serif;
 }


### PR DESCRIPTION
## Summary
- style pages with Piru brand colors and Gotham/BigFont typography
- add parrot logo and unified header across public pages
- remove committed parrot png asset per review

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29e86d028832b8f2a601b9413317c