### PR TITLE
Link site branding to home page

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   <header>
-    <img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" />
-    <h1>Piru</h1>
+    <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
+    <h1><a href="/" class="home-link">Piru</a></h1>
   </header>
   <main>
     <h2>Vocabulary Review</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
 </head>
 <body>
   <header>
-    <img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" />
-    <h1 data-i18n="site_name">Piru</h1>
+    <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
+    <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
     <p data-i18n="tagline">Consume media in foreign languages.</p>
   </header>
   <main>

--- a/public/stats.html
+++ b/public/stats.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   <header>
-    <img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" />
-    <h1>Piru</h1>
+    <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
+    <h1><a href="/" class="home-link">Piru</a></h1>
   </header>
   <main>
     <h2>Statistics</h2>

--- a/public/styles.css
+++ b/public/styles.css
@@ -33,6 +33,12 @@ header p {
   margin: 0;
 }
 
+.home-link,
+.home-link:visited {
+  color: inherit;
+  text-decoration: none;
+}
+
 .logo {
   width: 80px;
   height: auto;


### PR DESCRIPTION
### Summary
- Link logo and title in headers to the home page
- Style home links to inherit text color and remove underlines

### Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a2be5048832bbfabb623669636b8