### PR TITLE
style: switch titles to Gotham Black

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.cdnfonts.com/css/big-font');
 @import url('https://fonts.cdnfonts.com/css/gotham');
 
 :root {
@@ -25,7 +24,7 @@ header {
 }
 
 header h1 {
-  font-family: 'BigFont', sans-serif;
+  font-family: 'Gotham Black', 'Gotham', sans-serif;
   margin: 0.5rem 0 0;
 }
 
@@ -93,5 +92,5 @@ button:hover {
 #word {
   font-size: 2rem;
   margin-bottom: 1rem;
-  font-family: 'BigFont', sans-serif;
+  font-family: 'Gotham Black', 'Gotham', sans-serif;
 }


### PR DESCRIPTION
## Summary
- drop local BigFont assets
- use Gotham Black for headers and flashcard words

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a2a2029c832bb47f4643cd6acc5e