### PR TITLE
feat: add logout button to stats page

### DIFF
--- a/public/stats.html
+++ b/public/stats.html
@@ -16,6 +16,7 @@
     <p>Total words encountered: <span id="total-words">0</span></p>
     <p>Mastered words: <span id="mastered-words">0</span></p>
     <p><a href="flashcards.html">Review Vocabulary</a></p>
+    <button id="logout-button" class="hidden">Logout</button>
   </main>
   <script src="stats.js"></script>
 </body>

--- a/public/stats.js
+++ b/public/stats.js
@@ -1,9 +1,15 @@
 async function loadStats() {
   const userId = localStorage.getItem('userId');
+  const logoutButton = document.getElementById('logout-button');
   if (!userId) {
     window.location.href = '/';
     return;
   }
+  logoutButton.classList.remove('hidden');
+  logoutButton.addEventListener('click', () => {
+    localStorage.removeItem('userId');
+    window.location.href = '/';
+  });
   const res = await fetch(`/stats/overview?userId=${userId}`);
   if (res.ok) {
     const data = await res.json();


### PR DESCRIPTION
## Summary
- add logout button on the statistics page
- handle logout via local storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f89491f4832bb3351dfa33c8b140