### PR TITLE
Generalize native language validation

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -3,6 +3,9 @@ const crypto = require('crypto');
 // In-memory store for users
 const users = new Map();
 
+// Supported native languages
+const SUPPORTED_LANGUAGES = new Set(['en', 'fr', 'it', 'es', 'de']);
+
 function hashPassword(password) {
   return crypto.createHash('sha256').update(password).digest('hex');
 }
@@ -22,7 +25,7 @@ function signup(email, password, nativeLanguage, learningLanguages = []) {
   if (users.has(email)) {
     throw new Error('User already exists');
   }
-  if (nativeLanguage !== 'fr') {
+  if (!SUPPORTED_LANGUAGES.has(nativeLanguage)) {
     throw new Error('Native language not available');
   }
   const id = crypto.randomUUID();

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -8,10 +8,10 @@ describe('Authentication', () => {
   });
 
   it('signs up a new user and stores languages', () => {
-    const user = signup('alice@example.com', 'secret', 'fr', ['en', 'es']);
+    const user = signup('alice@example.com', 'secret', 'en', ['fr', 'es']);
     assert.strictEqual(user.email, 'alice@example.com');
-    assert.strictEqual(user.nativeLanguage, 'fr');
-    assert.deepStrictEqual(user.learningLanguages, ['en', 'es']);
+    assert.strictEqual(user.nativeLanguage, 'en');
+    assert.deepStrictEqual(user.learningLanguages, ['fr', 'es']);
   });
 
   it('prevents duplicate signups', () => {
@@ -19,8 +19,8 @@ describe('Authentication', () => {
     assert.throws(() => signup('bob@example.com', 'pass', 'fr', ['en']));
   });
 
-  it('rejects non-French native languages', () => {
-    assert.throws(() => signup('eve@example.com', 'pwd', 'en', []));
+  it('rejects unsupported native languages', () => {
+    assert.throws(() => signup('eve@example.com', 'pwd', 'jp', ['en']));
   });
 
   it('logs in an existing user', () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -30,18 +30,18 @@ describe('Auth API', () => {
   it('signs up a user', async () => {
     const res = await request(app)
       .post('/auth/signup')
-      .send({ email: 'api@example.com', password: 'secret', nativeLanguage: 'fr', learningLanguages: ['en'] });
+      .send({ email: 'api@example.com', password: 'secret', nativeLanguage: 'en', learningLanguages: ['fr'] });
     assert.strictEqual(res.status, 201);
     assert.ok(res.body.id);
     assert.strictEqual(res.body.email, 'api@example.com');
-    assert.strictEqual(res.body.nativeLanguage, 'fr');
-    assert.deepStrictEqual(res.body.learningLanguages, ['en']);
+    assert.strictEqual(res.body.nativeLanguage, 'en');
+    assert.deepStrictEqual(res.body.learningLanguages, ['fr']);
   });
 
-  it('rejects signup with non-French native language', async () => {
+  it('rejects signup with unsupported native language', async () => {
     const res = await request(app)
       .post('/auth/signup')
-      .send({ email: 'nofr@example.com', password: 'secret', nativeLanguage: 'en', learningLanguages: [] });
+      .send({ email: 'nofr@example.com', password: 'secret', nativeLanguage: 'jp', learningLanguages: ['en'] });
     assert.strictEqual(res.status, 400);
   });
 


### PR DESCRIPTION
## Summary
- Allow signup only if native language is one of en, fr, it, es, or de.
- Adjust auth and server tests for the expanded set of supported native languages.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb5547b4832b8d9d7959d6fbbdf0