### PR TITLE
feat: persist native language and localize pages

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -120,6 +120,9 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
   if (res.ok) {
     userId = data.id;
     localStorage.setItem('userId', userId);
+    if (data.nativeLanguage) {
+      localStorage.setItem('nativeLanguage', data.nativeLanguage);
+    }
     window.location.href = 'stats.html';
   } else {
     alert(data.error);

--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -12,21 +12,22 @@
     <h1><a href="/" class="home-link">Piru</a></h1>
   </header>
   <main>
-    <h2>Vocabulary Review</h2>
+    <h2 data-i18n="vocab_review">Vocabulary Review</h2>
     <section id="input-section">
-      <textarea id="input-text" placeholder="Paste text here"></textarea>
-      <button id="extract-btn">Extract Vocabulary</button>
+      <textarea id="input-text" placeholder="Paste text here" data-i18n-placeholder="paste_text"></textarea>
+      <button id="extract-btn" data-i18n="extract_vocabulary">Extract Vocabulary</button>
     </section>
     <section id="flashcard-section" class="hidden">
       <div id="word"></div>
       <div id="definition" class="hidden"></div>
-      <button id="show-btn">Show Definition</button>
+      <button id="show-btn" data-i18n="show_definition">Show Definition</button>
       <div id="review-buttons" class="hidden">
-        <button data-quality="1">Again</button>
-        <button data-quality="4">Good</button>
+        <button data-quality="1" data-i18n="again">Again</button>
+        <button data-quality="4" data-i18n="good">Good</button>
       </div>
     </section>
-  </main>
-  <script src="flashcards.js"></script>
-</body>
-</html>
+   </main>
+   <script src="/lib/i18next/umd/i18next.min.js"></script>
+   <script src="flashcards.js"></script>
+ </body>
+ </html>

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -1,3 +1,36 @@
+const resources = {
+  en: {
+    translation: {
+      vocab_review: 'Vocabulary Review',
+      paste_text: 'Paste text here',
+      extract_vocabulary: 'Extract Vocabulary',
+      show_definition: 'Show Definition',
+      again: 'Again',
+      good: 'Good'
+    }
+  },
+  fr: {
+    translation: {
+      vocab_review: 'Révision du vocabulaire',
+      paste_text: 'Collez le texte ici',
+      extract_vocabulary: 'Extraire le vocabulaire',
+      show_definition: 'Afficher la définition',
+      again: 'Encore',
+      good: 'Bon'
+    }
+  }
+};
+
+function updateContent() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = i18next.t(el.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = i18next.t(el.dataset.i18nPlaceholder);
+  });
+  document.documentElement.lang = i18next.language;
+}
+
 let currentWord = null;
 
 async function extractVocabulary() {
@@ -60,4 +93,8 @@ document.querySelectorAll('#review-buttons button').forEach((btn) => {
   btn.addEventListener('click', () => review(Number(btn.dataset.quality)));
 });
 
-loadNext();
+const lang = localStorage.getItem('nativeLanguage') || 'en';
+i18next.init({ lng: lang, resources }).then(() => {
+  updateContent();
+  loadNext();
+});

--- a/public/stats.html
+++ b/public/stats.html
@@ -12,12 +12,13 @@
     <h1><a href="/" class="home-link">Piru</a></h1>
   </header>
   <main>
-    <h2>Statistics</h2>
-    <p>Total words encountered: <span id="total-words">0</span></p>
-    <p>Mastered words: <span id="mastered-words">0</span></p>
-    <p><a href="flashcards.html">Review Vocabulary</a></p>
-    <button id="logout-button" class="hidden">Logout</button>
-  </main>
-  <script src="stats.js"></script>
-</body>
-</html>
+    <h2 data-i18n="stats_title">Statistics</h2>
+    <p><span data-i18n="total_words"></span>: <span id="total-words">0</span></p>
+    <p><span data-i18n="mastered_words"></span>: <span id="mastered-words">0</span></p>
+    <p><a href="flashcards.html" data-i18n="review_vocabulary">Review Vocabulary</a></p>
+    <button id="logout-button" class="hidden" data-i18n="logout">Logout</button>
+   </main>
+   <script src="/lib/i18next/umd/i18next.min.js"></script>
+   <script src="stats.js"></script>
+ </body>
+ </html>

--- a/public/stats.js
+++ b/public/stats.js
@@ -1,3 +1,34 @@
+const resources = {
+  en: {
+    translation: {
+      stats_title: 'Statistics',
+      total_words: 'Total words encountered',
+      mastered_words: 'Mastered words',
+      review_vocabulary: 'Review Vocabulary',
+      logout: 'Logout'
+    }
+  },
+  fr: {
+    translation: {
+      stats_title: 'Statistiques',
+      total_words: 'Nombre total de mots rencontrés',
+      mastered_words: 'Mots maîtrisés',
+      review_vocabulary: 'Réviser le vocabulaire',
+      logout: 'Déconnexion'
+    }
+  }
+};
+
+function updateContent() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = i18next.t(el.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = i18next.t(el.dataset.i18nPlaceholder);
+  });
+  document.documentElement.lang = i18next.language;
+}
+
 async function loadStats() {
   const userId = localStorage.getItem('userId');
   const logoutButton = document.getElementById('logout-button');
@@ -8,6 +39,7 @@ async function loadStats() {
   logoutButton.classList.remove('hidden');
   logoutButton.addEventListener('click', () => {
     localStorage.removeItem('userId');
+    localStorage.removeItem('nativeLanguage');
     window.location.href = '/';
   });
   const res = await fetch(`/stats/overview?userId=${userId}`);
@@ -18,4 +50,8 @@ async function loadStats() {
   }
 }
 
-loadStats();
+const lang = localStorage.getItem('nativeLanguage') || 'en';
+i18next.init({ lng: lang, resources }).then(() => {
+  updateContent();
+  loadStats();
+});


### PR DESCRIPTION
## Summary
- store user's native language on login
- initialize i18n on stats and flashcards pages using saved language
- translate page content and set document language attribute

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fb6f8ce0832b8d5f39a39557cdc7