### PR TITLE
feat: persist users in sqlite

### DIFF
--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -1,22 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-const sqlite3 = require('sqlite3').verbose();
+const { init, close } = require('../src/db');
 
-// Path to SQLite database file
-const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
-const dbPath = path.join(__dirname, '..', dbFile);
-// Path to schema SQL file
-const schemaPath = path.join(__dirname, '..', 'src', 'db', 'schema.sql');
-
-const schema = fs.readFileSync(schemaPath, 'utf8');
-
-const db = new sqlite3.Database(dbPath);
-
-db.exec(schema, (err) => {
-  if (err) {
+init()
+  .then(() => {
+    console.log('Database tables ensured.');
+    return close();
+  })
+  .catch((err) => {
     console.error('Failed to initialize database:', err.message);
     process.exit(1);
-  }
-  console.log('Database tables ensured.');
-  db.close();
-});
+  });

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,7 +1,6 @@
 const crypto = require('crypto');
 
-// In-memory store for users
-const users = new Map();
+const { db, clear } = require('./db');
 
 function hashPassword(password) {
   return crypto.createHash('sha256').update(password).digest('hex');
@@ -17,25 +16,39 @@ function hashPassword(password) {
  */
 function signup(email, password, nativeLanguage, learningLanguages = []) {
   if (!Array.isArray(learningLanguages) || learningLanguages.length === 0) {
-    throw new Error('At least one learning language is required');
-  }
-  if (users.has(email)) {
-    throw new Error('User already exists');
+    return Promise.reject(new Error('At least one learning language is required'));
   }
   if (nativeLanguage !== 'fr') {
-    throw new Error('Native language not available');
+    return Promise.reject(new Error('Native language not available'));
   }
   const id = crypto.randomUUID();
   const passwordHash = hashPassword(password);
-  const user = {
-    id,
-    email,
-    passwordHash,
-    nativeLanguage,
-    learningLanguages: [...learningLanguages],
-  };
-  users.set(email, user);
-  return { id, email, nativeLanguage, learningLanguages: [...learningLanguages] };
+  return new Promise((resolve, reject) => {
+    db.serialize(() => {
+      db.run(
+        'INSERT INTO users (id, email, password_hash, native_language) VALUES (?,?,?,?)',
+        [id, email, passwordHash, nativeLanguage],
+        (err) => {
+          if (err) {
+            if (err.message.includes('UNIQUE')) {
+              return reject(new Error('User already exists'));
+            }
+            return reject(err);
+          }
+          const stmt = db.prepare(
+            'INSERT INTO user_languages (user_id, language_code) VALUES (?, ?)'
+          );
+          for (const lang of learningLanguages) {
+            stmt.run(id, lang);
+          }
+          stmt.finalize((err2) => {
+            if (err2) return reject(err2);
+            resolve({ id, email, nativeLanguage, learningLanguages: [...learningLanguages] });
+          });
+        }
+      );
+    });
+  });
 }
 
 /**
@@ -45,21 +58,35 @@ function signup(email, password, nativeLanguage, learningLanguages = []) {
  * @returns {{id:string,email:string,nativeLanguage:string,learningLanguages:string[]}}
  */
 function login(email, password) {
-  const user = users.get(email);
-  if (!user) {
-    throw new Error('User not found');
-  }
-  const passwordHash = hashPassword(password);
-  if (user.passwordHash !== passwordHash) {
-    throw new Error('Invalid credentials');
-  }
-  const { id, nativeLanguage, learningLanguages } = user;
-  return { id, email, nativeLanguage, learningLanguages: [...learningLanguages] };
+  return new Promise((resolve, reject) => {
+    db.get('SELECT * FROM users WHERE email = ?', [email], (err, row) => {
+      if (err) return reject(err);
+      if (!row) return reject(new Error('User not found'));
+      const passwordHash = hashPassword(password);
+      if (row.password_hash !== passwordHash) {
+        return reject(new Error('Invalid credentials'));
+      }
+      db.all(
+        'SELECT language_code FROM user_languages WHERE user_id = ?',
+        [row.id],
+        (err2, rows) => {
+          if (err2) return reject(err2);
+          const learningLanguages = rows.map((r) => r.language_code);
+          resolve({
+            id: row.id,
+            email: row.email,
+            nativeLanguage: row.native_language,
+            learningLanguages,
+          });
+        }
+      );
+    });
+  });
 }
 
 // Helper for tests to clear users
 function _clearUsers() {
-  users.clear();
+  return clear();
 }
 
 module.exports = { signup, login, _clearUsers };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
+const dbPath = path.join(__dirname, '..', '..', dbFile);
+
+const db = new sqlite3.Database(dbPath);
+
+function init() {
+  const schemaPath = path.join(__dirname, 'schema.sql');
+  const schema = fs.readFileSync(schemaPath, 'utf8');
+  return new Promise((resolve, reject) => {
+    db.exec(schema, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+function clear() {
+  return new Promise((resolve, reject) => {
+    db.exec('DELETE FROM user_languages; DELETE FROM users;', (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+function close() {
+  return new Promise((resolve, reject) => {
+    db.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+module.exports = { db, init, clear, close };
+

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,40 +1,44 @@
-const { describe, it, beforeEach } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const assert = require('assert');
 const { signup, login, _clearUsers } = require('../src/auth');
+const { init } = require('../src/db');
 
 describe('Authentication', () => {
-  beforeEach(() => {
-    _clearUsers();
+  before(async () => {
+    await init();
+  });
+  beforeEach(async () => {
+    await _clearUsers();
   });
 
-  it('signs up a new user and stores languages', () => {
-    const user = signup('alice@example.com', 'secret', 'fr', ['en', 'es']);
+  it('signs up a new user and stores languages', async () => {
+    const user = await signup('alice@example.com', 'secret', 'fr', ['en', 'es']);
     assert.strictEqual(user.email, 'alice@example.com');
     assert.strictEqual(user.nativeLanguage, 'fr');
     assert.deepStrictEqual(user.learningLanguages, ['en', 'es']);
   });
 
-  it('prevents duplicate signups', () => {
-    signup('bob@example.com', 'pass', 'fr', ['en']);
-    assert.throws(() => signup('bob@example.com', 'pass', 'fr', ['en']));
+  it('prevents duplicate signups', async () => {
+    await signup('bob@example.com', 'pass', 'fr', ['en']);
+    await assert.rejects(() => signup('bob@example.com', 'pass', 'fr', ['en']));
   });
 
-  it('rejects non-French native languages', () => {
-    assert.throws(() => signup('eve@example.com', 'pwd', 'en', []));
+  it('rejects non-French native languages', async () => {
+    await assert.rejects(() => signup('eve@example.com', 'pwd', 'en', []));
   });
 
-  it('logs in an existing user', () => {
-    signup('carol@example.com', 'pwd', 'fr', ['en']);
-    const user = login('carol@example.com', 'pwd');
+  it('logs in an existing user', async () => {
+    await signup('carol@example.com', 'pwd', 'fr', ['en']);
+    const user = await login('carol@example.com', 'pwd');
     assert.strictEqual(user.email, 'carol@example.com');
   });
 
-  it('rejects invalid credentials', () => {
-    signup('dave@example.com', 'pwd', 'fr', ['en']);
-    assert.throws(() => login('dave@example.com', 'wrong'));
+  it('rejects invalid credentials', async () => {
+    await signup('dave@example.com', 'pwd', 'fr', ['en']);
+    await assert.rejects(() => login('dave@example.com', 'wrong'));
   });
 
-  it('requires at least one learning language', () => {
-    assert.throws(() => signup('eve@example.com', 'pwd', 'fr', []));
+  it('requires at least one learning language', async () => {
+    await assert.rejects(() => signup('eve@example.com', 'pwd', 'fr', []));
   });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const assert = require('assert');
 const request = require('supertest');
 
@@ -17,14 +17,20 @@ global.fetch = async () => ({
   }),
 });
 
-const app = require('../src/server');
+const { init } = require('../src/db');
+let app;
 const { _clearUsers } = require('../src/auth');
+
+before(async () => {
+  await init();
+  app = require('../src/server');
+});
 const { _clearWorks } = require('../src/works');
 const { _clear: _clearVocab } = require('../src/vocab');
 
 describe('Auth API', () => {
-  beforeEach(() => {
-    _clearUsers();
+  beforeEach(async () => {
+    await _clearUsers();
   });
 
   it('signs up a user', async () => {


### PR DESCRIPTION
## Summary
- add SQLite connection module with init/clear helpers
- persist signup and login to users and user_languages tables
- update tests and init script to use database

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fbba761c832b97a1ea1d2dbe830e