### PR TITLE
Add post-merge hook to run tests

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Git hook to run tests after merging or pulling changes
+# Usage: configure Git to use this hook by running:
+#   git config core.hooksPath .githooks
+
+echo "Running tests after merge..."
+npm test


### PR DESCRIPTION
## Summary
- add a git `post-merge` hook to automatically run `npm test`

## Testing
- `npm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ffe90c40832b9a0ebe4447416dc1