### PR TITLE
Fix authentication signup test

### DIFF
--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -10,8 +10,13 @@ describe('Authentication', () => {
   beforeEach(async () => {
     await _clearUsers();
   });
-  it('signs up a new user and stores languages', () => {
-    const user = signup('alice@example.com', 'secret', 'en', ['fr', 'es']);
+  it('signs up a new user and stores languages', async () => {
+    const user = await signup(
+      'alice@example.com',
+      'secret',
+      'en',
+      ['fr', 'es']
+    );
     assert.strictEqual(user.email, 'alice@example.com');
     assert.strictEqual(user.nativeLanguage, 'en');
     assert.deepStrictEqual(user.learningLanguages, ['fr', 'es']);


### PR DESCRIPTION
## Summary
- await asynchronous `signup` call in auth test to access returned user fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b301bcf6ec832ba92dda0abf9de2ec