### PR TITLE
Remove manual vocabulary input on learn page

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -13,10 +13,6 @@
   </header>
   <main>
     <h2 data-i18n="vocabulary_review"></h2>
-    <section id="input-section">
-      <textarea id="input-text" data-i18n-placeholder="paste_text_here" placeholder=""></textarea>
-      <button id="extract-btn" data-i18n="extract_vocabulary"></button>
-    </section>
     <section id="flashcard-section" class="hidden">
       <div id="word"></div>
       <div id="definition" class="hidden"></div>

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -1,45 +1,5 @@
 (function() {
-const flashcardResources = {
-  en: {
-    translation: {
-      vocabulary_review: 'Vocabulary Review',
-      paste_text_here: 'Paste text here',
-      extract_vocabulary: 'Extract Vocabulary',
-      show_definition: 'Show Definition',
-      again: 'Again',
-      good: 'Good'
-    }
-  },
-  fr: {
-    translation: {
-      vocabulary_review: 'Révision du vocabulaire',
-      paste_text_here: 'Collez le texte ici',
-      extract_vocabulary: 'Extraire le vocabulaire',
-      show_definition: 'Afficher la définition',
-      again: 'Encore',
-      good: 'Bon'
-    }
-  }
-};
-
 let currentWord = null;
-
-async function extractVocabulary() {
-  const text = document.getElementById('input-text').value;
-  const userId = localStorage.getItem('userId');
-  if (!userId) {
-    window.location.href = '/';
-    return;
-  }
-  if (!text.trim()) return;
-  await fetch('/vocab/extract', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, text })
-  });
-  document.getElementById('input-text').value = '';
-  loadNext();
-}
 
 async function loadNext() {
   const userId = localStorage.getItem('userId');
@@ -57,7 +17,7 @@ async function loadNext() {
     document.getElementById('review-buttons').classList.add('hidden');
     document.getElementById('show-btn').classList.remove('hidden');
   } else {
-    document.getElementById('flashcard-section').classList.add('hidden');
+    window.location.href = '/';
   }
 }
 
@@ -77,17 +37,12 @@ async function review(quality) {
   });
   loadNext();
 }
-
-document.getElementById('extract-btn').addEventListener('click', extractVocabulary);
 document.getElementById('show-btn').addEventListener('click', showDefinition);
 document.querySelectorAll('#review-buttons button').forEach((btn) => {
   btn.addEventListener('click', () => review(Number(btn.dataset.quality)));
 });
 
 initI18n().then(() => {
-  Object.keys(flashcardResources).forEach(lang => {
-    i18next.addResourceBundle(lang, 'translation', flashcardResources[lang].translation, true, true);
-  });
   updateContent();
   loadNext();
 });

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -26,8 +26,6 @@ const i18nResources = {
       view_stats: 'View Stats',
       logout: 'Logout',
       vocabulary_review: 'Vocabulary Review',
-      paste_text_here: 'Paste text here',
-      extract_vocabulary: 'Extract Vocabulary',
       show_definition: 'Show Definition',
       again: 'Again',
       good: 'Good'
@@ -59,8 +57,6 @@ const i18nResources = {
       view_stats: 'Voir ses stats',
       logout: 'Déconnexion',
       vocabulary_review: 'Révision du vocabulaire',
-      paste_text_here: 'Collez le texte ici',
-      extract_vocabulary: 'Extraire le vocabulaire',
       show_definition: 'Afficher la définition',
       again: 'Encore',
       good: 'Bien'
@@ -92,8 +88,6 @@ const i18nResources = {
       view_stats: 'Ver estadísticas',
       logout: 'Cerrar sesión',
       vocabulary_review: 'Revisión de vocabulario',
-      paste_text_here: 'Pega el texto aquí',
-      extract_vocabulary: 'Extraer vocabulario',
       show_definition: 'Mostrar definición',
       again: 'De nuevo',
       good: 'Bien'
@@ -125,8 +119,6 @@ const i18nResources = {
       view_stats: 'Vedi statistiche',
       logout: 'Esci',
       vocabulary_review: 'Revisione del vocabolario',
-      paste_text_here: 'Incolla il testo qui',
-      extract_vocabulary: 'Estrai vocabolario',
       show_definition: 'Mostra definizione',
       again: 'Di nuovo',
       good: 'Bene'
@@ -158,8 +150,6 @@ const i18nResources = {
       view_stats: 'Statistiken ansehen',
       logout: 'Abmelden',
       vocabulary_review: 'Vokabelwiederholung',
-      paste_text_here: 'Text hier einfügen',
-      extract_vocabulary: 'Vokabeln extrahieren',
       show_definition: 'Definition anzeigen',
       again: 'Nochmals',
       good: 'Gut'


### PR DESCRIPTION
## Summary
- Remove free-text vocabulary extraction from flashcards page
- Redirect to home when no vocabulary available to review
- Trim unused translation strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b308b392d0832bbbc97a9171ca1915