### PR TITLE
Allow all native language options on signup

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,11 @@
 let userId = localStorage.getItem('userId');
 
 const nativeLanguages = [
+  { code: 'en', label: '🇬🇧 English' },
+  { code: 'es', label: '🇪🇸 Español' },
   { code: 'fr', label: '🇫🇷 Français' },
-  { code: 'en', label: '🇬🇧 English' }
+  { code: 'de', label: '🇩🇪 Deutsch' },
+  { code: 'it', label: '🇮🇹 Italiano' }
 ];
 
 const learningLanguages = [
@@ -14,8 +17,6 @@ const learningLanguages = [
 ];
 
 const nativeSelect = document.getElementById('signup-native');
-const signupButton = document.querySelector('#signup-form button[type="submit"]');
-const languageError = document.getElementById('signup-language-error');
 nativeLanguages.forEach(({ code, label }) => {
   const option = document.createElement('option');
   option.value = code;
@@ -34,7 +35,6 @@ learningLanguages.forEach(({ code, label }) => {
 // Ensure the placeholder option remains selected by default
 nativeSelect.value = '';
 learningSelect.value = '';
-signupButton.disabled = true;
 
 const defaultLang = nativeSelect.value || 'en';
 initI18n(defaultLang);
@@ -43,13 +43,6 @@ document.getElementById('signup-native').addEventListener('change', (e) => {
   const lang = e.target.value;
   i18next.changeLanguage(lang);
   updateContent();
-  if (lang !== 'fr') {
-    signupButton.disabled = true;
-    languageError.classList.remove('hidden');
-  } else {
-    signupButton.disabled = false;
-    languageError.classList.add('hidden');
-  }
 });
 
 document.getElementById('login-form').addEventListener('submit', async (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,6 @@
         <select id="signup-native" required>
           <option value="" disabled selected data-i18n="native_language">Native language</option>
         </select>
-        <p id="signup-language-error" class="hidden" data-i18n="language_unavailable"></p>
         <select id="signup-learning" required>
           <option value="" disabled selected data-i18n="learning_language">Language to learn</option>
         </select>

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -17,6 +17,15 @@ describe('Authentication', () => {
     assert.deepStrictEqual(user.learningLanguages, ['fr', 'es']);
   });
 
+  it('allows all supported native languages', async () => {
+    const langs = ['en', 'fr', 'it', 'es', 'de'];
+    for (const lang of langs) {
+      const learning = lang === 'en' ? 'fr' : 'en';
+      const user = await signup(`${lang}@example.com`, 'secret', lang, [learning]);
+      assert.strictEqual(user.nativeLanguage, lang);
+    }
+  });
+
   it('prevents duplicate signups', async () => {
     await signup('bob@example.com', 'pass', 'fr', ['en']);
     await assert.rejects(() => signup('bob@example.com', 'pass', 'fr', ['en']));


### PR DESCRIPTION
## Summary
- Allow all supported languages as native options during signup and remove invalid language error
- Add test coverage for all supported native languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b309cef8b8832bb5047b7bb3a0cfab