### PR TITLE
feat: add hamburger navigation menu

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -132,20 +132,6 @@ function initAuthenticatedState() {
   loadWorks();
 }
 
-document.getElementById('learn-button').addEventListener('click', () => {
-  window.location.href = 'flashcards.html';
-});
-
-document.getElementById('stats-button').addEventListener('click', () => {
-  window.location.href = 'stats.html';
-});
-
-document.getElementById('logout-button').addEventListener('click', () => {
-  localStorage.removeItem('userId');
-  localStorage.removeItem('nativeLanguage');
-  window.location.href = '/';
-});
-
 if (userId) {
   initAuthenticatedState();
 }

--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -10,6 +10,14 @@
   <header>
     <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
     <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
+    <nav id="menu" class="hidden">
+      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
+      <div id="menu-options" class="hidden">
+        <button id="learn-button" data-i18n="learn">Learn</button>
+        <button id="stats-button" data-i18n="view_stats">View Stats</button>
+        <button id="logout-button" data-i18n="logout">Logout</button>
+      </div>
+    </nav>
   </header>
   <main>
     <h2 data-i18n="vocabulary_review"></h2>
@@ -26,5 +34,6 @@
   <script src="/lib/i18next/umd/i18next.min.js"></script>
   <script src="i18n.js"></script>
   <script src="flashcards.js"></script>
+  <script src="menu.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,14 @@
     <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
     <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
     <p data-i18n="tagline">Consume media in foreign languages.</p>
+    <nav id="menu" class="hidden">
+      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
+      <div id="menu-options" class="hidden">
+        <button id="learn-button" data-i18n="learn">Learn</button>
+        <button id="stats-button" data-i18n="view_stats">View Stats</button>
+        <button id="logout-button" data-i18n="logout">Logout</button>
+      </div>
+    </nav>
   </header>
   <main>
     <section id="auth">
@@ -34,11 +42,6 @@
         <button type="submit" data-i18n="sign_up">Sign Up</button>
       </form>
     </section>
-    <section id="menu" class="hidden">
-      <button id="learn-button" data-i18n="learn">Learn</button>
-      <button id="stats-button" data-i18n="view_stats">View Stats</button>
-      <button id="logout-button" data-i18n="logout">Logout</button>
-    </section>
     <section id="works" class="hidden">
       <h2 data-i18n="your_works">Your Works</h2>
       <form id="work-form">
@@ -53,5 +56,6 @@
   <script src="/lib/i18next/umd/i18next.min.js"></script>
   <script src="i18n.js"></script>
   <script src="app.js"></script>
+  <script src="menu.js"></script>
 </body>
 </html>

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,0 +1,29 @@
+(function() {
+  function setupMenu() {
+    const menu = document.getElementById('menu');
+    const toggle = document.getElementById('menu-toggle');
+    const options = document.getElementById('menu-options');
+    if (!menu || !toggle || !options) return;
+    const userId = localStorage.getItem('userId');
+    if (!userId) {
+      menu.classList.add('hidden');
+      return;
+    }
+    menu.classList.remove('hidden');
+    toggle.addEventListener('click', () => {
+      options.classList.toggle('hidden');
+    });
+    document.getElementById('learn-button').addEventListener('click', () => {
+      window.location.href = 'flashcards.html';
+    });
+    document.getElementById('stats-button').addEventListener('click', () => {
+      window.location.href = 'stats.html';
+    });
+    document.getElementById('logout-button').addEventListener('click', () => {
+      localStorage.removeItem('userId');
+      localStorage.removeItem('nativeLanguage');
+      window.location.href = '/';
+    });
+  }
+  document.addEventListener('DOMContentLoaded', setupMenu);
+})();

--- a/public/stats.html
+++ b/public/stats.html
@@ -10,16 +10,24 @@
   <header>
     <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
     <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
+    <nav id="menu" class="hidden">
+      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
+      <div id="menu-options" class="hidden">
+        <button id="learn-button" data-i18n="learn">Learn</button>
+        <button id="stats-button" data-i18n="view_stats">View Stats</button>
+        <button id="logout-button" data-i18n="logout">Logout</button>
+      </div>
+    </nav>
   </header>
   <main>
     <h2 data-i18n="statistics"></h2>
     <p><span data-i18n="total_words_encountered"></span> <span id="total-words">0</span></p>
     <p><span data-i18n="mastered_words"></span> <span id="mastered-words">0</span></p>
     <p><a href="flashcards.html" data-i18n="review_vocabulary"></a></p>
-    <button id="logout-button" class="hidden" data-i18n="logout"></button>
   </main>
   <script src="/lib/i18next/umd/i18next.min.js"></script>
   <script src="i18n.js"></script>
   <script src="stats.js"></script>
+  <script src="menu.js"></script>
 </body>
 </html>

--- a/public/stats.js
+++ b/public/stats.js
@@ -5,8 +5,7 @@ const statsResources = {
       statistics: 'Statistics',
       total_words_encountered: 'Total words encountered',
       mastered_words: 'Mastered words',
-      review_vocabulary: 'Review Vocabulary',
-      logout: 'Logout'
+      review_vocabulary: 'Review Vocabulary'
     }
   },
   fr: {
@@ -14,25 +13,17 @@ const statsResources = {
       statistics: 'Statistiques',
       total_words_encountered: 'Nombre total de mots rencontrés',
       mastered_words: 'Mots maîtrisés',
-      review_vocabulary: 'Réviser le vocabulaire',
-      logout: 'Déconnexion'
+      review_vocabulary: 'Réviser le vocabulaire'
     }
   }
 };
 
 async function loadStats() {
   const userId = localStorage.getItem('userId');
-  const logoutButton = document.getElementById('logout-button');
   if (!userId) {
     window.location.href = '/';
     return;
   }
-  logoutButton.classList.remove('hidden');
-  logoutButton.addEventListener('click', () => {
-    localStorage.removeItem('userId');
-    localStorage.removeItem('nativeLanguage');
-    window.location.href = '/';
-  });
   const res = await fetch(`/stats/overview?userId=${userId}`);
   if (res.ok) {
     const data = await res.json();

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,6 +22,7 @@ header {
   text-align: center;
   padding: 1rem;
   box-shadow: 0 2px 4px rgba(34, 31, 31, 0.1);
+  position: relative;
 }
 
 header h1 {
@@ -100,4 +101,29 @@ button:hover {
   font-size: 2rem;
   margin-bottom: 1rem;
   font-family: 'Gotham Black', 'Gotham', sans-serif;
+}
+
+#menu {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.burger-button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+#menu-options {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: #fff;
+  box-shadow: 0 2px 8px rgba(34, 31, 31, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add hamburger menu to site header with Learn, View Stats, and Logout options
- introduce shared menu script for navigation and logout handling
- style menu and clean up redundant logout logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31eae04dc832b9134639bf246f4fd