### PR TITLE
Fix statistics page link localization

### DIFF
--- a/public/stats.js
+++ b/public/stats.js
@@ -1,24 +1,4 @@
- (function() {
-const statsResources = {
-  en: {
-    translation: {
-      statistics: 'Statistics',
-      total_words_encountered: 'Total words encountered',
-      mastered_words: 'Mastered words',
-      review_vocabulary: 'Review Vocabulary',
-      logout: 'Logout'
-    }
-  },
-  fr: {
-    translation: {
-      statistics: 'Statistiques',
-      total_words_encountered: 'Nombre total de mots rencontrés',
-      mastered_words: 'Mots maîtrisés',
-      review_vocabulary: 'Réviser le vocabulaire',
-      logout: 'Déconnexion'
-    }
-  }
-};
+(function() {
 
 async function loadStats() {
   const userId = localStorage.getItem('userId');
@@ -41,10 +21,8 @@ async function loadStats() {
   }
 }
 
-initI18n().then(() => {
-  Object.keys(statsResources).forEach(lang => {
-    i18next.addResourceBundle(lang, 'translation', statsResources[lang].translation, true, true);
-  });
+const defaultLang = localStorage.getItem('nativeLanguage') || 'en';
+initI18n(defaultLang).then(() => {
   updateContent();
   loadStats();
 });


### PR DESCRIPTION
## Summary
- Load user's stored language on statistics page so the review link and other text show in the correct locale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31ed6ed3c832ba62844a2684adad8