### PR TITLE
Add spacing below tagline for homepage

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -30,7 +30,7 @@ header h1 {
 }
 
 header p {
-  margin: 0;
+  margin: 0.5rem 0 0;
 }
 
 .home-link,


### PR DESCRIPTION
## Summary
- add top margin to header tagline so "Consume media in foreign languages" is further below the site name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31f454ff8832b8dfcdc0f2bb8db97