### PR TITLE
Fix flashcards language detection

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -42,7 +42,8 @@ document.querySelectorAll('#review-buttons button').forEach((btn) => {
   btn.addEventListener('click', () => review(Number(btn.dataset.quality)));
 });
 
-initI18n().then(() => {
+const defaultLang = localStorage.getItem('nativeLanguage') || 'en';
+initI18n(defaultLang).then(() => {
   updateContent();
   loadNext();
 });


### PR DESCRIPTION
## Summary
- use stored nativeLanguage when initializing flashcards view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b321cd8160832ba6c566933d933973