### PR TITLE
Use button for vocabulary review

### DIFF
--- a/public/stats.html
+++ b/public/stats.html
@@ -23,7 +23,7 @@
     <h2 data-i18n="statistics"></h2>
     <p><span data-i18n="total_words_encountered"></span> <span id="total-words">0</span></p>
     <p><span data-i18n="mastered_words"></span> <span id="mastered-words">0</span></p>
-    <p><a href="flashcards.html" data-i18n="review_vocabulary"></a></p>
+    <p><button id="review-vocab-button" data-i18n="review_vocabulary"></button></p>
   </main>
   <script src="/lib/i18next/umd/i18next.min.js"></script>
   <script src="i18n.js"></script>

--- a/public/stats.js
+++ b/public/stats.js
@@ -14,6 +14,10 @@ async function loadStats() {
   }
 }
 
+document.getElementById('review-vocab-button').addEventListener('click', () => {
+  window.location.href = 'flashcards.html';
+});
+
 const defaultLang = localStorage.getItem('nativeLanguage') || 'en';
 initI18n(defaultLang).then(() => {
   updateContent();


### PR DESCRIPTION
## Summary
- Replace "Réviser le vocabulaire" anchor in stats page with a button
- Add click handler to navigate to flashcards page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3223ac5e8832bb430f39ae382d5ff