### PR TITLE
Hide burger menu options until clicked

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -127,3 +127,7 @@ button:hover {
   gap: 0.5rem;
   padding: 0.5rem;
 }
+
+#menu-options.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Ensure burger menu options are hidden by default using a CSS rule that targets `#menu-options.hidden`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3237bcca4832b85a267f3d76dfa82