### PR TITLE
Handle empty vocabulary on learn page

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -16,6 +16,13 @@ async function loadNext() {
     document.getElementById('definition').classList.add('hidden');
     document.getElementById('review-buttons').classList.add('hidden');
     document.getElementById('show-btn').classList.remove('hidden');
+  } else if (res.status === 204) {
+    currentWord = null;
+    document.getElementById('word').textContent = i18next.t('no_words');
+    document.getElementById('flashcard-section').classList.remove('hidden');
+    document.getElementById('definition').classList.add('hidden');
+    document.getElementById('review-buttons').classList.add('hidden');
+    document.getElementById('show-btn').classList.add('hidden');
   } else {
     window.location.href = '/';
   }

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -28,7 +28,8 @@ const i18nResources = {
       vocabulary_review: 'Vocabulary Review',
       show_definition: 'Show Definition',
       again: 'Again',
-      good: 'Good'
+      good: 'Good',
+      no_words: 'No words to review'
     }
   },
   fr: {
@@ -59,7 +60,8 @@ const i18nResources = {
       vocabulary_review: 'Révision du vocabulaire',
       show_definition: 'Afficher la définition',
       again: 'Encore',
-      good: 'Bien'
+      good: 'Bien',
+      no_words: 'Aucun mot à réviser'
     }
   },
   es: {
@@ -90,7 +92,8 @@ const i18nResources = {
       vocabulary_review: 'Revisión de vocabulario',
       show_definition: 'Mostrar definición',
       again: 'De nuevo',
-      good: 'Bien'
+      good: 'Bien',
+      no_words: 'No hay palabras para repasar'
     }
   },
   it: {
@@ -121,7 +124,8 @@ const i18nResources = {
       vocabulary_review: 'Revisione del vocabolario',
       show_definition: 'Mostra definizione',
       again: 'Di nuovo',
-      good: 'Bene'
+      good: 'Bene',
+      no_words: 'Nessuna parola da ripassare'
     }
   },
   de: {
@@ -152,7 +156,8 @@ const i18nResources = {
       vocabulary_review: 'Vokabelwiederholung',
       show_definition: 'Definition anzeigen',
       again: 'Nochmals',
-      good: 'Gut'
+      good: 'Gut',
+      no_words: 'Keine Wörter zu wiederholen'
     }
   }
 };


### PR DESCRIPTION
## Summary
- Avoid redirecting when no vocabulary is available and show a "no words" message on the flashcards page
- Add translations for the new message across supported languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b326d0804c832ba7ac5be97b914748