### PR TITLE
Add OpenAI smoke test

### DIFF
--- a/test/openai-smoke.test.js
+++ b/test/openai-smoke.test.js
@@ -1,0 +1,17 @@
+const { it } = require('node:test');
+const assert = require('assert');
+
+it(
+  'queries OpenAI models endpoint with OPENAI_API_KEY_TEST',
+  { skip: !process.env.OPENAI_API_KEY_TEST, concurrency: false, timeout: 60000 },
+  async () => {
+    const res = await fetch('https://api.openai.com/v1/models', {
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY_TEST}`,
+      },
+    });
+    assert.ok(res.ok, `expected ok response, got ${res.status}`);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.data), 'response missing data array');
+  }
+);


### PR DESCRIPTION
## Summary
- add smoke test that calls OpenAI models endpoint using `OPENAI_API_KEY_TEST`
- skip test when `OPENAI_API_KEY_TEST` is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4470237d4832b97b6ce004016fe7a