### PR TITLE
Use links instead of buttons in burger menu

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -16,10 +16,10 @@
     <nav id="menu" class="hidden">
       <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
       <div id="menu-options" class="hidden">
-        <button id="works-button" data-i18n="my_works">My Works</button>
-        <button id="learn-button" data-i18n="learn">Learn</button>
-        <button id="stats-button" data-i18n="view_stats">View Stats</button>
-        <button id="logout-button" data-i18n="logout">Logout</button>
+        <a id="works-link" href="/" data-i18n="my_works">My Works</a>
+        <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
+        <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
+        <a id="logout-link" href="/" data-i18n="logout">Logout</a>
       </div>
     </nav>
   </header>

--- a/public/index.html
+++ b/public/index.html
@@ -17,10 +17,10 @@
     <nav id="menu" class="hidden">
       <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
       <div id="menu-options" class="hidden">
-        <button id="works-button" data-i18n="my_works">My Works</button>
-        <button id="learn-button" data-i18n="learn">Learn</button>
-        <button id="stats-button" data-i18n="view_stats">View Stats</button>
-        <button id="logout-button" data-i18n="logout">Logout</button>
+        <a id="works-link" href="/" data-i18n="my_works">My Works</a>
+        <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
+        <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
+        <a id="logout-link" href="/" data-i18n="logout">Logout</a>
       </div>
     </nav>
   </header>

--- a/public/menu.js
+++ b/public/menu.js
@@ -9,23 +9,15 @@
       options.classList.toggle('hidden');
     });
 
-    document.getElementById('works-button').addEventListener('click', () => {
-      window.location.href = '/';
-    });
-
-    document.getElementById('learn-button').addEventListener('click', () => {
-      window.location.href = 'flashcards.html';
-    });
-
-    document.getElementById('stats-button').addEventListener('click', () => {
-      window.location.href = 'stats.html';
-    });
-
-    document.getElementById('logout-button').addEventListener('click', () => {
-      localStorage.removeItem('userId');
-      localStorage.removeItem('nativeLanguage');
-      window.location.href = '/';
-    });
+    const logoutLink = document.getElementById('logout-link');
+    if (logoutLink) {
+      logoutLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        localStorage.removeItem('userId');
+        localStorage.removeItem('nativeLanguage');
+        window.location.href = '/';
+      });
+    }
 
     const userId = localStorage.getItem('userId');
     if (!userId) {

--- a/public/stats.html
+++ b/public/stats.html
@@ -16,10 +16,10 @@
     <nav id="menu" class="hidden">
       <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
       <div id="menu-options" class="hidden">
-        <button id="works-button" data-i18n="my_works">My Works</button>
-        <button id="learn-button" data-i18n="learn">Learn</button>
-        <button id="stats-button" data-i18n="view_stats">View Stats</button>
-        <button id="logout-button" data-i18n="logout">Logout</button>
+        <a id="works-link" href="/" data-i18n="my_works">My Works</a>
+        <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
+        <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
+        <a id="logout-link" href="/" data-i18n="logout">Logout</a>
       </div>
     </nav>
   </header>

--- a/public/styles.css
+++ b/public/styles.css
@@ -136,6 +136,17 @@ button:hover {
   padding: 0.5rem;
 }
 
+#menu-options a {
+  padding: 0.5rem 1rem;
+  color: var(--color-dark);
+  text-decoration: none;
+}
+
+#menu-options a:hover {
+  background-color: var(--color-blue);
+  color: var(--color-light);
+}
+
 #menu-options.hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Replace burger menu buttons with anchor links across public pages for navigation
- Simplify menu script to handle logout via link click and keep menu toggle
- Add styles for new menu links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b458340ce8832b876d42e555a66181