### PR TITLE
Simplify vocab extraction output

### DIFF
--- a/scripts/extract-vocab-cli.js
+++ b/scripts/extract-vocab-cli.js
@@ -15,9 +15,7 @@ async function main() {
   const text = fs.readFileSync(file, 'utf8');
   try {
     const vocab = await extractVocabularyWithLLM(text);
-    for (const { word } of vocab) {
-      console.log(word);
-    }
+    console.log(vocab);
   } catch (err) {
     console.error('Extraction failed', err.message);
     process.exit(1);

--- a/src/chatgpt.js
+++ b/src/chatgpt.js
@@ -66,14 +66,6 @@ async function extractVocabularyWithLLM(text, outPath) {
     }
   }
 
-  const mapped = items.map((item) => ({
-    id: crypto.randomUUID(),
-    word: item.word,
-    definition: item.definition,
-    citations: [item.citation],
-    status: 'new',
-  }));
-
   try {
     const outputPath =
       outPath ||
@@ -81,12 +73,12 @@ async function extractVocabularyWithLLM(text, outPath) {
         os.tmpdir(),
         `difficult-words-${crypto.randomUUID()}.json`
       );
-    fs.writeFileSync(outputPath, JSON.stringify(mapped, null, 2), 'utf8');
+    fs.writeFileSync(outputPath, JSON.stringify(items, null, 2), 'utf8');
   } catch (err) {
     console.error('Failed to write difficult words file', err);
   }
 
-  return mapped;
+  return items;
 }
 
 module.exports = { extractVocabularyWithLLM };

--- a/src/vocab.js
+++ b/src/vocab.js
@@ -1,4 +1,5 @@
 const { sm2 } = require('./sm2');
+const crypto = require('crypto');
 
 // In-memory vocabulary store: userId -> Map(wordId -> word data)
 const vocab = new Map();
@@ -13,6 +14,7 @@ function addWords(userId, words) {
   words.forEach((w) => {
     const entry = {
       ...w,
+      id: w.id || crypto.randomUUID(),
       interval: 0,
       repetitions: 0,
       easiness: 2.5,


### PR DESCRIPTION
## Summary
- Return unmodified items from `extractVocabularyWithLLM` and write them to disk
- CLI prints the raw vocabulary response instead of iterating words
- Ensure added vocabulary entries have an ID even when missing

## Testing
- `npm run extract-vocab -- test/fixtures/en-fr/sample.txt`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b462988174832b96e52c09bb647f71