### PR TITLE
fix: vertically center menu items

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -143,6 +143,7 @@ button:hover {
   text-decoration: none;
   display: flex;
   align-items: center;
+  line-height: 1;
 }
 
 #menu-options a:hover {


### PR DESCRIPTION
## Summary
- normalize line height so menu items sit centered within their hover highlight

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4666c4a74832b9d7e961bf33e1bfb