### PR TITLE
fix: vertically center menu items

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -138,7 +138,7 @@ button:hover {
 }
 
 #menu-options a {
-  padding: 0.5rem 1rem;
+  padding: 0.65rem 1rem 0.35rem 1rem;
   color: var(--color-dark);
   text-decoration: none;
   display: flex;


### PR DESCRIPTION
## Summary
- tweak menu link padding for perfect vertical alignment inside hover highlight

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4666c4a74832b9d7e961bf33e1bfb