### PR TITLE
feat: display user email and menu icons

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -59,6 +59,9 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
   if (res.ok) {
     userId = data.id;
     localStorage.setItem('userId', userId);
+    if (data.email) {
+      localStorage.setItem('email', data.email);
+    }
     if (data.nativeLanguage) {
       localStorage.setItem('nativeLanguage', data.nativeLanguage);
       i18next.changeLanguage(data.nativeLanguage);
@@ -132,6 +135,14 @@ function initAuthenticatedState() {
   document.getElementById('auth').classList.add('hidden');
   document.getElementById('menu').classList.remove('hidden');
   document.getElementById('works').classList.remove('hidden');
+  const email = localStorage.getItem('email');
+  const options = document.getElementById('menu-options');
+  if (email && options && !document.getElementById('menu-email')) {
+    const emailDiv = document.createElement('div');
+    emailDiv.id = 'menu-email';
+    emailDiv.textContent = email;
+    options.prepend(emailDiv);
+  }
   loadWorks();
 }
 

--- a/public/menu.js
+++ b/public/menu.js
@@ -15,6 +15,7 @@
         e.preventDefault();
         localStorage.removeItem('userId');
         localStorage.removeItem('nativeLanguage');
+        localStorage.removeItem('email');
         window.location.href = '/';
       });
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -146,6 +146,19 @@ button:hover {
   line-height: 1;
 }
 
+#menu-email {
+  padding: 0.65rem 1rem 0.35rem 1rem;
+  color: var(--color-dark);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+#menu-email::before {
+  content: '👤';
+  margin-right: 0.5rem;
+}
+
 #menu-options a:hover {
   background-color: var(--color-blue);
   color: var(--color-light);
@@ -153,4 +166,19 @@ button:hover {
 
 #menu-options.hidden {
   display: none;
+}
+
+#works-link::before {
+  content: '📚';
+  margin-right: 0.5rem;
+}
+
+#learn-link::before {
+  content: '🧠';
+  margin-right: 0.5rem;
+}
+
+#stats-link::before {
+  content: '📈';
+  margin-right: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- show logged-in user's email at top of burger menu
- decorate burger menu entries with icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46c59f958832bbbcb7397a5f02c62