### PR TITLE
fix: update vocabulary list schema

### DIFF
--- a/test/chatgpt.test.js
+++ b/test/chatgpt.test.js
@@ -33,9 +33,11 @@ describe('extractVocabularyWithLLM', { concurrency: false }, () => {
           choices: [
             {
               message: {
-                content: JSON.stringify([
-                  { word: 'mockword', definition: 'mock def', citation: 'mock cit' },
-                ]),
+                content: JSON.stringify({
+                  items: [
+                    { word: 'mockword', definition: 'mock def', citation: 'mock cit' },
+                  ],
+                }),
               },
             },
           ],


### PR DESCRIPTION
## Summary
- revise vocabulary extraction schema to wrap items inside an object for OpenAI response_format
- adjust parsing logic to read items from new schema
- update tests to reflect new response shape

## Testing
- `npm test`
- `npm run extract-vocab -- test/fixtures/en-fr/sample.txt` *(fails: Missing OpenAI API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b46cadf3bc832b8f52c41dba643ba6