### PR TITLE
Add admin interface for user and data management

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
+    <nav id="menu">
+      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
+      <div id="menu-options" class="hidden">
+        <a id="works-link" href="/">My Works</a>
+        <a id="learn-link" href="flashcards.html">Learn</a>
+        <a id="stats-link" href="stats.html">View Stats</a>
+        <a id="logout-link" href="/">Logout</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Users</h2>
+      <ul id="user-list"></ul>
+    </section>
+    <section>
+      <h2>Works</h2>
+      <ul id="admin-work-list"></ul>
+    </section>
+  </main>
+  <script src="admin.js"></script>
+  <script src="menu.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,44 @@
+const adminId = localStorage.getItem('userId');
+
+async function loadUsers() {
+  const res = await fetch(`/admin/users?userId=${adminId}`);
+  const users = await res.json();
+  const list = document.getElementById('user-list');
+  list.innerHTML = '';
+  users.forEach((u) => {
+    const li = document.createElement('li');
+    li.textContent = `${u.email} (${u.id})`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Delete';
+    btn.addEventListener('click', async () => {
+      await fetch(`/admin/users/${u.id}?userId=${adminId}`, { method: 'DELETE' });
+      loadUsers();
+    });
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+async function loadWorks() {
+  const res = await fetch(`/admin/works?userId=${adminId}`);
+  const works = await res.json();
+  const list = document.getElementById('admin-work-list');
+  list.innerHTML = '';
+  works.forEach((w) => {
+    const li = document.createElement('li');
+    li.textContent = `${w.title || 'Untitled'} by ${w.author || 'Unknown'}`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Delete';
+    btn.addEventListener('click', async () => {
+      await fetch(`/admin/works/${w.id}?userId=${adminId}`, { method: 'DELETE' });
+      loadWorks();
+    });
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadUsers();
+  loadWorks();
+});

--- a/public/app.js
+++ b/public/app.js
@@ -67,6 +67,9 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
       i18next.changeLanguage(data.nativeLanguage);
       updateContent();
     }
+    if (typeof data.isAdmin !== 'undefined') {
+      localStorage.setItem('isAdmin', data.isAdmin);
+    }
     initAuthenticatedState();
   } else {
     alert(data.error);
@@ -142,6 +145,13 @@ function initAuthenticatedState() {
     emailDiv.id = 'menu-email';
     emailDiv.textContent = email;
     options.prepend(emailDiv);
+  }
+  if (options && localStorage.getItem('isAdmin') === 'true' && !document.getElementById('admin-link')) {
+    const adminLink = document.createElement('a');
+    adminLink.id = 'admin-link';
+    adminLink.href = 'admin.html';
+    adminLink.textContent = 'Admin';
+    options.appendChild(adminLink);
   }
   loadWorks();
 }

--- a/public/menu.js
+++ b/public/menu.js
@@ -16,6 +16,7 @@
         localStorage.removeItem('userId');
         localStorage.removeItem('nativeLanguage');
         localStorage.removeItem('email');
+        localStorage.removeItem('isAdmin');
         window.location.href = '/';
       });
     }

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,0 +1,37 @@
+const { db } = require('./db');
+
+function isAdmin(userId) {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT is_admin FROM users WHERE id = ?', [userId], (err, row) => {
+      if (err) return reject(err);
+      if (!row) return resolve(false);
+      resolve(row.is_admin === 1);
+    });
+  });
+}
+
+function listUsers() {
+  return new Promise((resolve, reject) => {
+    db.all('SELECT id, email, native_language, is_admin FROM users', (err, rows) => {
+      if (err) return reject(err);
+      const users = rows.map((r) => ({
+        id: r.id,
+        email: r.email,
+        nativeLanguage: r.native_language,
+        isAdmin: !!r.is_admin,
+      }));
+      resolve(users);
+    });
+  });
+}
+
+function deleteUser(id) {
+  return new Promise((resolve, reject) => {
+    db.run('DELETE FROM users WHERE id = ?', [id], function (err) {
+      if (err) return reject(err);
+      resolve(this.changes > 0);
+    });
+  });
+}
+
+module.exports = { isAdmin, listUsers, deleteUser };

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS users (
     email TEXT UNIQUE NOT NULL,
     password_hash TEXT NOT NULL,
     native_language TEXT NOT NULL,
+    is_admin INTEGER DEFAULT 0,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/src/works.js
+++ b/src/works.js
@@ -31,8 +31,22 @@ function listWorks(userId) {
     .map(({ id, title, author, vocab }) => ({ id, title, author, vocab }));
 }
 
+function listAllWorks() {
+  return Array.from(works.values()).map(({ id, userId, title, author, vocab }) => ({
+    id,
+    userId,
+    title,
+    author,
+    vocab,
+  }));
+}
+
+function deleteWork(id) {
+  return works.delete(id);
+}
+
 function _clearWorks() {
   works.clear();
 }
 
-module.exports = { addWork, listWorks, _clearWorks };
+module.exports = { addWork, listWorks, listAllWorks, deleteWork, _clearWorks };

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -1,0 +1,78 @@
+const { describe, it, before, beforeEach } = require('node:test');
+const assert = require('assert');
+const request = require('supertest');
+
+process.env.OPENAI_API_KEY = 'test';
+global.fetch = async () => ({
+  json: async () => ({
+    choices: [
+      {
+        message: {
+          content: JSON.stringify([
+            { word: 'mockword', definition: 'mock definition', citation: 'mock citation' },
+          ]),
+        },
+      },
+    ],
+  }),
+});
+
+const { init } = require('../src/db');
+let app;
+const { _clearUsers } = require('../src/auth');
+const { _clearWorks } = require('../src/works');
+
+describe('Admin API', () => {
+  before(async () => {
+    await init();
+    app = require('../src/server');
+  });
+
+  beforeEach(async () => {
+    await _clearUsers();
+    _clearWorks();
+  });
+
+  it('allows admin to list users', async () => {
+    const adminRes = await request(app)
+      .post('/auth/signup')
+      .send({ email: 'admin@example.com', password: 'pass', nativeLanguage: 'en', learningLanguages: ['fr'], isAdmin: true });
+    const adminId = adminRes.body.id;
+    await request(app)
+      .post('/auth/signup')
+      .send({ email: 'user@example.com', password: 'pass', nativeLanguage: 'fr', learningLanguages: ['en'] });
+    const res = await request(app)
+      .get('/admin/users')
+      .query({ userId: adminId });
+    assert.strictEqual(res.status, 200);
+    assert.ok(res.body.length >= 2);
+  });
+
+  it('prevents non-admin from accessing user list', async () => {
+    await request(app)
+      .post('/auth/signup')
+      .send({ email: 'admin2@example.com', password: 'pass', nativeLanguage: 'en', learningLanguages: ['fr'], isAdmin: true });
+    const userRes = await request(app)
+      .post('/auth/signup')
+      .send({ email: 'user2@example.com', password: 'pass', nativeLanguage: 'fr', learningLanguages: ['en'] });
+    const res = await request(app)
+      .get('/admin/users')
+      .query({ userId: userRes.body.id });
+    assert.strictEqual(res.status, 403);
+  });
+
+  it('lists works for admin', async () => {
+    const adminRes = await request(app)
+      .post('/auth/signup')
+      .send({ email: 'admin3@example.com', password: 'pass', nativeLanguage: 'en', learningLanguages: ['fr'], isAdmin: true });
+    const adminId = adminRes.body.id;
+    await request(app)
+      .post('/works')
+      .send({ userId: 'u1', title: 'Book', author: 'A', content: 'An extraordinary narrative.' });
+    const res = await request(app)
+      .get('/admin/works')
+      .query({ userId: adminId });
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `is_admin` flag to users and extend auth flow
- introduce admin endpoints to manage users and works
- add simple admin UI for listing and deleting users and works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b499e81f94832b8f4676287a82518a