### PR TITLE
Add server proxy for lyrics and client error handling

### DIFF
--- a/public/works.js
+++ b/public/works.js
@@ -84,9 +84,15 @@ document.getElementById('movie-search-form')?.addEventListener('submit', async (
 });
 
 async function searchLyrics(query) {
-  const res = await fetch(`https://api.lyrics.ovh/suggest/${encodeURIComponent(query)}`);
-  const data = await res.json();
-  return data.data || [];
+  try {
+    const res = await fetch(`/api/lyrics/search?q=${encodeURIComponent(query)}`);
+    if (!res.ok) throw new Error('Search failed');
+    const data = await res.json();
+    return data.data || [];
+  } catch (err) {
+    alert('Failed to search lyrics');
+    return [];
+  }
 }
 
 function renderLyricsResults(results) {
@@ -97,16 +103,31 @@ function renderLyricsResults(results) {
     const btn = document.createElement('button');
     btn.textContent = i18next.t('add');
     btn.addEventListener('click', async () => {
-      const lyricRes = await fetch(`https://api.lyrics.ovh/v1/${encodeURIComponent(song.artist.name)}/${encodeURIComponent(song.title)}`);
-      const lyricData = await lyricRes.json();
-      const content = lyricData.lyrics || '';
-      const res = await fetch('/works', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, title: song.title, author: song.artist.name, content, type: 'song' })
-      });
-      if (res.ok) {
-        loadWorks();
+      try {
+        const lyricRes = await fetch(
+          `/api/lyrics/text?artist=${encodeURIComponent(song.artist.name)}&title=${encodeURIComponent(song.title)}`
+        );
+        if (!lyricRes.ok) throw new Error('Lyrics fetch failed');
+        const lyricData = await lyricRes.json();
+        const content = lyricData.lyrics || '';
+        const res = await fetch('/works', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            userId,
+            title: song.title,
+            author: song.artist.name,
+            content,
+            type: 'song'
+          })
+        });
+        if (res.ok) {
+          loadWorks();
+        } else {
+          throw new Error('Add failed');
+        }
+      } catch (err) {
+        alert('Failed to add song');
       }
     });
     li.appendChild(btn);

--- a/src/server.js
+++ b/src/server.js
@@ -152,6 +152,31 @@ app.post('/vocab/review', (req, res) => {
   }
 });
 
+// Lyrics endpoints
+app.get('/api/lyrics/search', async (req, res) => {
+  const { q } = req.query;
+  try {
+    const r = await fetch(
+      `https://api.lyrics.ovh/suggest/${encodeURIComponent(q)}`
+    );
+    res.json(await r.json());
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to search lyrics' });
+  }
+});
+
+app.get('/api/lyrics/text', async (req, res) => {
+  const { artist, title } = req.query;
+  try {
+    const r = await fetch(
+      `https://api.lyrics.ovh/v1/${encodeURIComponent(artist)}/${encodeURIComponent(title)}`
+    );
+    res.json(await r.json());
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch lyrics' });
+  }
+});
+
 // Stats endpoints
 app.get('/stats/overview', (req, res) => {
   const { userId } = req.query;


### PR DESCRIPTION
## Summary
- add `/api/lyrics/search` and `/api/lyrics/text` endpoints to proxy lyrics.ovh API
- update client lyrics search to use server proxy with try/catch alerts

## Testing
- `npm test` *(fails: Admin API lists works for admin)*

------
https://chatgpt.com/codex/tasks/task_e_68b49bf5cf68832bad85b77976e7e1ad