### PR TITLE
Allow works with empty content

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -48,7 +48,9 @@ app.post('/auth/login', async (req, res) => {
 // Works endpoints
 app.post('/works', async (req, res) => {
   const { userId, title, author, content, type } = req.body;
-  if (!userId || !content || !type) {
+  // `content` may be an empty string if no preview text is available, so we only
+  // validate that the field exists rather than requiring a truthy value.
+  if (!userId || typeof content === 'undefined' || !type) {
     return res.status(400).json({ error: 'Missing userId, content, or type' });
   }
   try {


### PR DESCRIPTION
## Summary
- allow adding works even when no preview text is available by accepting empty content values

## Testing
- `npm test` *(fails: allows admin to list users, lists works for admin)*

------
https://chatgpt.com/codex/tasks/task_e_68b49ebfb1cc832b96a7f9af697a78e9