### PR TITLE
Handle is_admin column migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Consume media in foreign languages by translating only the difficult vocabulary and by learning it.",
   "main": "index.js",
   "scripts": {
-    "test": "node --test",
+    "test": "NODE_ENV=test node scripts/initDb.js && node --test",
     "init-db": "node scripts/initDb.js",
     "init-db:staging": "NODE_ENV=staging node scripts/initDb.js",
     "start": "node src/server.js",

--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -1,3 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
+const dbPath = path.join(__dirname, '..', dbFile);
+
+if (process.env.NODE_ENV === 'test' && fs.existsSync(dbPath)) {
+  fs.unlinkSync(dbPath);
+}
+
 const { init, close } = require('../src/db');
 
 init()

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -12,8 +12,22 @@ function init() {
   const schema = fs.readFileSync(schemaPath, 'utf8');
   return new Promise((resolve, reject) => {
     db.exec(schema, (err) => {
-      if (err) reject(err);
-      else resolve();
+      if (err) return reject(err);
+      db.all("PRAGMA table_info(users);", (err, rows) => {
+        if (err) return reject(err);
+        const hasIsAdmin = rows.some((row) => row.name === 'is_admin');
+        if (!hasIsAdmin) {
+          db.run(
+            'ALTER TABLE users ADD COLUMN is_admin INTEGER DEFAULT 0',
+            (err) => {
+              if (err) return reject(err);
+              resolve();
+            }
+          );
+        } else {
+          resolve();
+        }
+      });
     });
   });
 }

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -68,7 +68,7 @@ describe('Admin API', () => {
     const adminId = adminRes.body.id;
     await request(app)
       .post('/works')
-      .send({ userId: 'u1', title: 'Book', author: 'A', content: 'An extraordinary narrative.' });
+      .send({ userId: 'u1', title: 'Book', author: 'A', content: 'An extraordinary narrative.', type: 'book' });
     const res = await request(app)
       .get('/admin/works')
       .query({ userId: adminId });

--- a/test/db-migration.test.js
+++ b/test/db-migration.test.js
@@ -1,0 +1,52 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+process.env.NODE_ENV = 'staging';
+const dbFile = path.join(__dirname, '..', 'piru-staging.sqlite');
+
+describe('Database migration', () => {
+  before(() => {
+    if (fs.existsSync(dbFile)) {
+      fs.unlinkSync(dbFile);
+    }
+    return new Promise((resolve, reject) => {
+      const tmpDb = new sqlite3.Database(dbFile);
+      const oldSchema = `CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        email TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        native_language TEXT NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );`;
+      tmpDb.exec(oldSchema, (err) => {
+        tmpDb.close((closeErr) => {
+          if (err || closeErr) reject(err || closeErr);
+          else resolve();
+        });
+      });
+    });
+  });
+
+  it('adds is_admin column when missing', async () => {
+    const { init, db, close } = require('../src/db');
+    await init();
+    const columns = await new Promise((resolve, reject) => {
+      db.all('PRAGMA table_info(users);', (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows);
+      });
+    });
+    const hasIsAdmin = columns.some((col) => col.name === 'is_admin');
+    assert.strictEqual(hasIsAdmin, true);
+    await close();
+  });
+
+  after(() => {
+    if (fs.existsSync(dbFile)) {
+      fs.unlinkSync(dbFile);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `init()` adds missing `is_admin` column with default 0
- reset database before tests and add migration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a0acd33c832b82928b666a087c67