### PR TITLE
chore: silence test console output

### DIFF
--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -12,7 +12,9 @@ const { init, close } = require('../src/db');
 
 init()
   .then(() => {
-    console.log('Database tables ensured.');
+    if (process.env.NODE_ENV !== 'test') {
+      console.log('Database tables ensured.');
+    }
     return close();
   })
   .catch((err) => {

--- a/test/openai-integration.test.js
+++ b/test/openai-integration.test.js
@@ -49,10 +49,13 @@ it(
           )
         );
         const items = await extractVocabularyWithLLM(text);
-        console.log(items);
         const itemsLemma = items.map((i) => i.lemma).sort().join(' ');
         const expectedLemma = expected.map((i) => i.lemma).sort().join(' ');
         const sim = similarity(itemsLemma, expectedLemma);
+        if (sim <= 0.8) {
+          console.error('Actual:', items);
+          console.error('Expected:', expected);
+        }
         assert.ok(
           sim > 0.8,
           `Levenshtein similarity below threshold for ${file}: ${sim}`


### PR DESCRIPTION
## Summary
- avoid logging database init success in tests
- log OpenAI integration test responses only on failure
- include expected items in OpenAI test failure output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a2b752d8832ba8741097ce06cfca