### PR TITLE
fix: store sqlite database in cwd

### DIFF
--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
-const dbPath = path.join(__dirname, '..', dbFile);
+// Use the current working directory for the SQLite database so that the
+// initialization script works even when the project files are installed in a
+// read-only location (for example when Piru is installed globally).
+const dbPath = path.join(process.cwd(), dbFile);
 
 if (process.env.NODE_ENV === 'test' && fs.existsSync(dbPath)) {
   fs.unlinkSync(dbPath);

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -3,7 +3,13 @@ const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 
 const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
-const dbPath = path.join(__dirname, '..', '..', dbFile);
+// Store the SQLite database in the current working directory instead of the
+// module directory. When Piru is installed as a dependency or run globally,
+// the module directory may be read-only, which would prevent SQLite from
+// creating or writing to the database file and result in a SQLITE_READONLY
+// error. Using `process.cwd()` ensures the database lives in a writable
+// location for the running user.
+const dbPath = path.join(process.cwd(), dbFile);
 
 const db = new sqlite3.Database(dbPath);
 


### PR DESCRIPTION
## Summary
- store SQLite DB in current working directory to avoid read-only module path
- ensure init script uses cwd so DB can be created when installed globally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a571ab8c832b8bf5ab3b23119234