### PR TITLE
feat: centralize navigation menu

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -9,15 +9,7 @@
 <body>
   <header>
     <a href="/"><img src="parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
-    <nav id="menu">
-      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
-      <div id="menu-options" class="hidden">
-        <a id="works-link" href="/">My Works</a>
-        <a id="learn-link" href="flashcards.html">Learn</a>
-        <a id="stats-link" href="stats.html">View Stats</a>
-        <a id="logout-link" href="/">Logout</a>
-      </div>
-    </nav>
+    <nav id="menu" class="hidden"></nav>
   </header>
   <main>
     <section>

--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -13,15 +13,7 @@
       <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
       <p data-i18n="tagline">Consume media in foreign languages.</p>
     </div>
-    <nav id="menu" class="hidden">
-      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
-      <div id="menu-options" class="hidden">
-        <a id="works-link" href="/" data-i18n="my_works">My Works</a>
-        <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
-        <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
-        <a id="logout-link" href="/" data-i18n="logout">Logout</a>
-      </div>
-    </nav>
+    <nav id="menu" class="hidden"></nav>
   </header>
   <main>
     <h2 data-i18n="vocabulary_review"></h2>

--- a/public/index.html
+++ b/public/index.html
@@ -14,15 +14,7 @@
       <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
       <p data-i18n="tagline">Consume media in foreign languages.</p>
     </div>
-    <nav id="menu" class="hidden">
-      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
-      <div id="menu-options" class="hidden">
-        <a id="works-link" href="/" data-i18n="my_works">My Works</a>
-        <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
-        <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
-        <a id="logout-link" href="/" data-i18n="logout">Logout</a>
-      </div>
-    </nav>
+    <nav id="menu" class="hidden"></nav>
   </header>
   <main>
     <section id="auth">

--- a/public/menu.html
+++ b/public/menu.html
@@ -1,0 +1,7 @@
+<button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
+<div id="menu-options" class="hidden">
+  <a id="works-link" href="/" data-i18n="my_works">My Works</a>
+  <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
+  <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
+  <a id="logout-link" href="/" data-i18n="logout">Logout</a>
+</div>

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,15 +1,30 @@
 (function() {
-  function setupMenu() {
+  function loadMenu() {
     const menu = document.getElementById('menu');
-    const toggle = document.getElementById('menu-toggle');
-    const options = document.getElementById('menu-options');
-    if (!menu || !toggle || !options) return;
+    if (!menu) return;
+
+    fetch('/menu.html')
+      .then((res) => res.text())
+      .then((html) => {
+        menu.innerHTML = html;
+        if (typeof updateContent === 'function') {
+          updateContent();
+        }
+        setupMenu(menu);
+      })
+      .catch((err) => console.error('Failed to load menu:', err));
+  }
+
+  function setupMenu(menu) {
+    const toggle = menu.querySelector('#menu-toggle');
+    const options = menu.querySelector('#menu-options');
+    if (!toggle || !options) return;
 
     toggle.addEventListener('click', () => {
       options.classList.toggle('hidden');
     });
 
-    const logoutLink = document.getElementById('logout-link');
+    const logoutLink = menu.querySelector('#logout-link');
     if (logoutLink) {
       logoutLink.addEventListener('click', (e) => {
         e.preventDefault();
@@ -28,5 +43,6 @@
       menu.classList.remove('hidden');
     }
   }
-  document.addEventListener('DOMContentLoaded', setupMenu);
+
+  document.addEventListener('DOMContentLoaded', loadMenu);
 })();

--- a/public/stats.html
+++ b/public/stats.html
@@ -13,15 +13,7 @@
       <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
       <p data-i18n="tagline">Consume media in foreign languages.</p>
     </div>
-    <nav id="menu" class="hidden">
-      <button id="menu-toggle" class="burger-button" aria-label="Menu">&#9776;</button>
-      <div id="menu-options" class="hidden">
-        <a id="works-link" href="/" data-i18n="my_works">My Works</a>
-        <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
-        <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
-        <a id="logout-link" href="/" data-i18n="logout">Logout</a>
-      </div>
-    </nav>
+    <nav id="menu" class="hidden"></nav>
   </header>
   <main>
     <h2 data-i18n="statistics"></h2>


### PR DESCRIPTION
## Summary
- centralize menu markup in `menu.html`
- load menu via JavaScript to reuse across pages
- update all public pages to use dynamic menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a61444bc832b96e9e7b3bc516fe8