### PR TITLE
Add loading spinner for search queries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,7 @@
         <form id="book-search-form">
           <input type="text" id="book-search-input" data-i18n-placeholder="search_books" placeholder="Search a book" />
           <button type="submit" data-i18n="search">Search</button>
+          <span id="book-search-spinner" class="spinner hidden"></span>
         </form>
         <ul id="book-results" class="search-results"></ul>
       </div>
@@ -52,6 +53,7 @@
         <form id="movie-search-form">
           <input type="text" id="movie-search-input" data-i18n-placeholder="search_movies_series" placeholder="Search a film or TV series" />
           <button type="submit" data-i18n="search">Search</button>
+          <span id="movie-search-spinner" class="spinner hidden"></span>
         </form>
         <ul id="movie-results" class="search-results"></ul>
       </div>
@@ -60,6 +62,7 @@
         <form id="lyrics-search-form">
           <input type="text" id="lyrics-search-input" data-i18n-placeholder="search_lyrics" placeholder="Search a song" />
           <button type="submit" data-i18n="search">Search</button>
+          <span id="lyrics-search-spinner" class="spinner hidden"></span>
         </form>
         <ul id="lyrics-results" class="search-results"></ul>
       </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -200,6 +200,21 @@ button:hover {
   margin-right: 0.5rem;
 }
 
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-gray);
+  border-top-color: var(--color-dark);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 #work-table {
   width: 100%;
   border-collapse: collapse;

--- a/public/works.js
+++ b/public/works.js
@@ -36,10 +36,22 @@ function renderBookResults(results) {
 
 document.getElementById('book-search-form')?.addEventListener('submit', async (e) => {
   e.preventDefault();
-  const query = document.getElementById('book-search-input').value.trim();
+  const input = document.getElementById('book-search-input');
+  const button = e.target.querySelector('button[type="submit"]');
+  const spinner = document.getElementById('book-search-spinner');
+  const query = input.value.trim();
   if (!query) return;
-  const results = await searchBooks(query);
-  renderBookResults(results);
+  button.disabled = true;
+  input.disabled = true;
+  spinner.classList.remove('hidden');
+  try {
+    const results = await searchBooks(query);
+    renderBookResults(results);
+  } finally {
+    button.disabled = false;
+    input.disabled = false;
+    spinner.classList.add('hidden');
+  }
 });
 
 async function searchMovies(query) {
@@ -77,10 +89,22 @@ function renderMovieResults(results) {
 
 document.getElementById('movie-search-form')?.addEventListener('submit', async (e) => {
   e.preventDefault();
-  const query = document.getElementById('movie-search-input').value.trim();
+  const input = document.getElementById('movie-search-input');
+  const button = e.target.querySelector('button[type="submit"]');
+  const spinner = document.getElementById('movie-search-spinner');
+  const query = input.value.trim();
   if (!query) return;
-  const results = await searchMovies(query);
-  renderMovieResults(results);
+  button.disabled = true;
+  input.disabled = true;
+  spinner.classList.remove('hidden');
+  try {
+    const results = await searchMovies(query);
+    renderMovieResults(results);
+  } finally {
+    button.disabled = false;
+    input.disabled = false;
+    spinner.classList.add('hidden');
+  }
 });
 
 async function searchLyrics(query) {
@@ -147,12 +171,24 @@ function renderLyricsResults(results) {
 
 document.getElementById('lyrics-search-form')?.addEventListener('submit', async (e) => {
   e.preventDefault();
-  const query = document.getElementById('lyrics-search-input').value.trim();
+  const input = document.getElementById('lyrics-search-input');
+  const button = e.target.querySelector('button[type="submit"]');
+  const spinner = document.getElementById('lyrics-search-spinner');
+  const query = input.value.trim();
   if (!query) return;
-  const results = await searchLyrics(query);
-  if (Array.isArray(results)) {
-    renderLyricsResults(results);
-  } else {
-    alert(i18next.t('lyrics_fetch_failed'));
+  button.disabled = true;
+  input.disabled = true;
+  spinner.classList.remove('hidden');
+  try {
+    const results = await searchLyrics(query);
+    if (Array.isArray(results)) {
+      renderLyricsResults(results);
+    } else {
+      alert(i18next.t('lyrics_fetch_failed'));
+    }
+  } finally {
+    button.disabled = false;
+    input.disabled = false;
+    spinner.classList.add('hidden');
   }
 });


### PR DESCRIPTION
## Summary
- show a CSS spinner next to each search form
- disable search input and button while fetching and hide spinner when done

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b555eb7c48832bbd751329a8041329