### PR TITLE
Add mapping CSV for English books

### DIFF
--- a/data/books/mapping.csv
+++ b/data/books/mapping.csv
@@ -1,0 +1,2 @@
+author,title,filename
+"Toni Morrison","The Bluest Eye","the-bluest-eye.epub"


### PR DESCRIPTION
## Summary
- add mapping for available English ebook with author, title, and filename

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b604839050832b9ff30f445cc8926a