### PR TITLE
Add movie thumbnails and work-specific flashcards

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Consume media in foreign languages by translating only the difficult vocabulary and by learning it.",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test node scripts/initDb.js && node --test",
+    "test": "NODE_ENV=test node scripts/initDb.js && node --test --test-concurrency=1",
     "init-db": "node scripts/initDb.js",
     "init-db:staging": "NODE_ENV=staging node scripts/initDb.js",
     "start": "node src/server.js",

--- a/public/app.js
+++ b/public/app.js
@@ -146,8 +146,18 @@ async function loadWorks() {
     caption.className = 'work-caption';
     caption.textContent = w.title || 'Untitled';
     item.appendChild(caption);
+    const learnBtn = document.createElement('button');
+    learnBtn.className = 'learn-btn';
+    learnBtn.textContent = i18next.t('learn');
+    learnBtn.addEventListener('click', () => {
+      window.location.href = `flashcards.html?workId=${encodeURIComponent(w.id)}`;
+    });
+    item.appendChild(learnBtn);
     carousel.appendChild(item);
   });
+  if (typeof updateContent === 'function') {
+    updateContent();
+  }
 }
 
 function initAuthenticatedState() {

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -1,5 +1,7 @@
 (function() {
 let currentWord = null;
+const params = new URLSearchParams(window.location.search);
+const workId = params.get('workId');
 
 async function loadNext() {
   const userId = localStorage.getItem('userId');
@@ -7,7 +9,7 @@ async function loadNext() {
     window.location.href = '/';
     return;
   }
-  const res = await fetch(`/vocab/next?userId=${userId}`);
+  const res = await fetch(`/vocab/next?userId=${userId}${workId ? `&workId=${workId}` : ''}`);
   if (res.status === 200) {
     currentWord = await res.json();
     document.getElementById('word').textContent = currentWord.word;

--- a/public/styles.css
+++ b/public/styles.css
@@ -250,8 +250,9 @@ button:disabled {
 
 .work-item {
   flex: 0 0 auto;
-  width: 150px;
+  width: 75px;
   text-align: center;
+  position: relative;
 }
 
 .work-item img {
@@ -261,14 +262,28 @@ button:disabled {
 }
 
 .work-placeholder {
-  width: 150px;
-  height: 220px;
+  width: 75px;
+  height: 110px;
   display: flex;
   align-items: center;
   justify-content: center;
   background-color: var(--color-gray);
   color: var(--color-light);
   border-radius: 4px;
+}
+
+.learn-btn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: none;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.work-item:hover .learn-btn {
+  display: block;
 }
 
 .work-caption {

--- a/public/works.js
+++ b/public/works.js
@@ -79,10 +79,11 @@ function renderMovieResults(results) {
       const detailRes = await fetch(`https://www.omdbapi.com/?apikey=thewdb&i=${movie.imdbID}&plot=full`);
       const detail = await detailRes.json();
       const content = detail.Plot || '';
+      const poster = detail.Poster && detail.Poster !== 'N/A' ? detail.Poster : undefined;
       const res = await fetch('/works', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, title: detail.Title, author: '', content, type })
+        body: JSON.stringify({ userId, title: detail.Title, author: '', content, type, thumbnail: poster })
       });
       if (res.ok) {
         loadWorks();

--- a/src/server.js
+++ b/src/server.js
@@ -66,14 +66,14 @@ app.delete('/auth/account', async (req, res) => {
 
 // Works endpoints
 app.post('/works', async (req, res) => {
-  const { userId, title, author, content, type } = req.body;
+  const { userId, title, author, content, type, thumbnail } = req.body;
   // `content` may be an empty string if no preview text is available, so we only
   // validate that the field exists rather than requiring a truthy value.
   if (!userId || typeof content === 'undefined' || !type) {
     return res.status(400).json({ error: 'Missing userId, content, or type' });
   }
   try {
-    const work = await addWork(userId, title, author, content, type);
+    const work = await addWork(userId, title, author, content, type, thumbnail);
     res.status(201).json(work);
   } catch (err) {
     res.status(500).json({ error: 'Extraction failed' });
@@ -151,11 +151,11 @@ app.post('/vocab/extract', async (req, res) => {
 });
 
 app.get('/vocab/next', (req, res) => {
-  const { userId } = req.query;
+  const { userId, workId } = req.query;
   if (!userId) {
     return res.status(400).json({ error: 'Missing userId' });
   }
-  const word = getNextWord(userId);
+  const word = getNextWord(userId, workId);
   if (!word) return res.status(204).end();
   res.json(word);
 });

--- a/src/vocab.js
+++ b/src/vocab.js
@@ -26,11 +26,13 @@ function addWords(userId, words) {
   return added;
 }
 
-function getNextWord(userId) {
+function getNextWord(userId, workId) {
   const store = vocab.get(userId);
   if (!store) return null;
   const now = Date.now();
-  const dueWords = Array.from(store.values()).filter((w) => w.due <= now);
+  const dueWords = Array.from(store.values()).filter(
+    (w) => w.due <= now && (!workId || w.workId === workId)
+  );
   if (dueWords.length === 0) return null;
   dueWords.sort((a, b) => a.due - b.due);
   return dueWords[0];

--- a/src/works.js
+++ b/src/works.js
@@ -111,7 +111,7 @@ function getThumbnailForTitle(title) {
  * @param {string} content
  * @returns {{id:string,title:string,author:string,vocab:Object[]}}
  */
-async function addWork(userId, title, author, content, type) {
+async function addWork(userId, title, author, content, type, thumbnailUrl) {
   const id = crypto.randomUUID();
   let text = content;
   if (type === 'movie') {
@@ -121,13 +121,28 @@ async function addWork(userId, title, author, content, type) {
     }
   }
   const vocab = await chatgpt.extractVocabularyWithLLM(text);
-  const thumbnail = type === 'movie' ? getThumbnailForTitle(title) : null;
-  const work = { id, userId, title, author, content, type, vocab, thumbnail };
+  const vocabWithWork = Array.isArray(vocab)
+    ? vocab.map((v) => ({ ...v, workId: id }))
+    : [];
+  const thumbnail =
+    type === 'movie'
+      ? getThumbnailForTitle(title) || thumbnailUrl || null
+      : null;
+  const work = {
+    id,
+    userId,
+    title,
+    author,
+    content,
+    type,
+    vocab: vocabWithWork,
+    thumbnail,
+  };
   works.set(id, work);
-  if (Array.isArray(vocab) && vocab.length) {
-    addWords(userId, vocab);
+  if (vocabWithWork.length) {
+    addWords(userId, vocabWithWork);
   }
-  return { id, title, author, type, vocab, thumbnail };
+  return { id, title, author, type, vocab: vocabWithWork, thumbnail };
 }
 
 /**

--- a/test/works.test.js
+++ b/test/works.test.js
@@ -76,4 +76,25 @@ describe('Works management', () => {
     assert.ok(next);
     assert.strictEqual(next.word, 'mcgonagall');
   });
+
+  it('filters vocabulary by work id', async () => {
+    chatgpt.extractVocabularyWithLLM = async (content) => {
+      const tokens = content.toLowerCase().match(/\b\w+\b/g) || [];
+      const unique = Array.from(new Set(tokens));
+      return unique.map((word) => ({
+        id: crypto.randomUUID(),
+        word,
+        definition: '',
+        citations: [],
+        status: 'new',
+      }));
+    };
+    const w1 = await addWork('fUser', 'First', '', 'alpha beta', 'book');
+    const w2 = await addWork('fUser', 'Second', '', 'gamma delta', 'book');
+    const next1 = getNextWord('fUser', w1.id);
+    const next2 = getNextWord('fUser', w2.id);
+    assert.notStrictEqual(next1.id, next2.id);
+    assert.ok(['alpha', 'beta'].includes(next1.word));
+    assert.ok(['gamma', 'delta'].includes(next2.word));
+  });
 });


### PR DESCRIPTION
## Summary
- Display movie poster thumbnails in carousel when available, falling back to local mapping.
- Shrink carousel thumbnails and show a hover "Learn" button linking to work-specific flashcards.
- Support work-specific vocabulary by associating words with their work and filtering in flashcards.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6a0420c832b97d8ecab153e4872