### PR TITLE
Handle missing users when deleting accounts

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -55,9 +55,15 @@ app.delete('/auth/account', async (req, res) => {
     return res.status(400).json({ error: 'Missing userId' });
   }
   try {
-    await deleteUser(userId);
+    // Remove any user-specific data before deleting the actual user record.
+    // This prevents potential foreign key constraint errors and keeps the
+    // in-memory stores in sync with the database.
     deleteUserWorks(userId);
     deleteUserVocab(userId);
+    const deleted = await deleteUser(userId);
+    if (!deleted) {
+      return res.status(404).json({ error: 'User not found' });
+    }
     res.status(204).end();
   } catch (err) {
     res.status(500).json({ error: 'Failed to delete account' });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -103,6 +103,13 @@ describe('Auth API', () => {
       .send({ email: 'delete@example.com', password: 'secret' });
     assert.strictEqual(loginRes.status, 401);
   });
+
+  it('returns 404 when deleting a non-existent account', async () => {
+    const res = await request(app)
+      .delete('/auth/account')
+      .query({ userId: 'missing-user' });
+    assert.strictEqual(res.status, 404);
+  });
 });
 
 describe('Works API', () => {


### PR DESCRIPTION
## Summary
- Remove user-related data before deleting database record to avoid errors
- Return `404` when an account does not exist
- Test account deletion error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d7c548f0832b81d2ff949d3dd435