### PR TITLE
Style add work menu

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -2,6 +2,7 @@
 
 :root {
   --color-yellow: #fdd301;
+  --color-yellow-light: #fff9c4;
   --color-blue: #46c7f4;
   --color-pink: #ff2a63;
   --color-light: #edf2f2;
@@ -223,6 +224,7 @@ button:disabled {
 
 #add-work-menu {
   display: flex;
+  justify-content: space-between;
   gap: 0.5rem;
   margin: 1rem 0;
   background-color: var(--color-yellow);
@@ -231,14 +233,21 @@ button:disabled {
 }
 
 #add-work-menu .tab {
+  flex: 1;
+  text-align: center;
   padding: 0.5rem 1rem;
   cursor: pointer;
   border-radius: 4px;
+  background-color: var(--color-yellow-light);
+}
+
+#add-work-menu .tab:hover {
+  text-decoration: underline;
 }
 
 #add-work-menu .tab.active {
-  background-color: var(--color-blue);
-  color: var(--color-light);
+  background-color: var(--color-yellow);
+  color: var(--color-dark);
 }
 
 .carousel {


### PR DESCRIPTION
## Summary
- Justify "Add New Work" menu options and space them evenly
- Use yellow color scheme with lighter inactive tabs and underline on hover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6fe2a09b8832bbc014d410c70446e