### PR TITLE
Add title and author variables to vocabulary prompt

### DIFF
--- a/prompts/extract-vocabulary-en-fr.txt
+++ b/prompts/extract-vocabulary-en-fr.txt
@@ -5,6 +5,7 @@ Tu es un expert de l’enseignement de l’anglais pour des étudiants français
 * les références à des personnes, des lieux ou des objets d’usage de l’époque.
 
 ⚠️ Tu ne mentionnes pas les mots dont la traduction française est évidente (par ex. "table" → "table").
+Tu n'identifies pas comme « difficile » les noms de personnage ou les noms propres évidents dans le contexte de l'œuvre (par exemple, dans Harry Potter, ne sélectionne pas les sorts de magie, les noms de professeur ou le mot « Quidditch »).
 Tu ne sélectionnes que le vocabulaire **vraiment difficile** ou **trompeur pour un francophone**.
 
 Ta réponse doit être en **format JSON strict**, avec les clés suivantes :
@@ -225,6 +226,8 @@ Si aucun mot n’est difficile, tu renvoies un JSON vide : `[]`.
 ### Application
 
 Maintenant, réalise la fiche de vocabulaire du texte suivant :
+Titre : """TITLE"""
+Auteur : """AUTHOR"""
 
 ```
 """TEXT"""


### PR DESCRIPTION
## Summary
- include title and author placeholders in the vocabulary extraction prompt
- clarify instructions to ignore obvious character or proper names when choosing difficult vocabulary

## Testing
- `npm test` *(fails: Cannot find module 'jszip')*

------
https://chatgpt.com/codex/tasks/task_e_68b7041f904c832bbb9e702dc695ebdd