### PR TITLE
Ensure work actions overlay only thumbnails

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -174,28 +174,28 @@ async function loadWorks() {
     works.forEach((w) => {
       const item = document.createElement('div');
       item.className = 'work-item';
+
+      const thumb = document.createElement('div');
+      thumb.className = 'work-thumb';
       if (w.thumbnail) {
         const img = document.createElement('img');
         img.src = w.thumbnail;
         img.alt = w.title || 'thumbnail';
-        item.appendChild(img);
+        thumb.appendChild(img);
       } else {
         const placeholder = document.createElement('div');
         placeholder.className = 'work-placeholder';
         placeholder.textContent = i18next.t(w.type);
-        item.appendChild(placeholder);
+        thumb.appendChild(placeholder);
       }
-      const caption = document.createElement('div');
-      caption.className = 'work-caption';
-      caption.textContent = w.title || 'Untitled';
-      item.appendChild(caption);
+
       const learnBtn = document.createElement('button');
       learnBtn.className = 'learn-btn';
       learnBtn.textContent = i18next.t('learn');
       learnBtn.addEventListener('click', () => {
         window.location.href = `flashcards.html?workId=${encodeURIComponent(w.id)}`;
       });
-      item.appendChild(learnBtn);
+      thumb.appendChild(learnBtn);
 
       const deleteBtn = document.createElement('button');
       deleteBtn.className = 'delete-btn';
@@ -209,7 +209,15 @@ async function loadWorks() {
           loadWorks();
         }
       });
-      item.appendChild(deleteBtn);
+      thumb.appendChild(deleteBtn);
+
+      item.appendChild(thumb);
+
+      const caption = document.createElement('div');
+      caption.className = 'work-caption';
+      caption.textContent = w.title || 'Untitled';
+      item.appendChild(caption);
+
       carousel.appendChild(item);
     });
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -273,7 +273,6 @@ button:disabled {
   flex: 0 0 auto;
   width: 75px;
   text-align: center;
-  position: relative;
 }
 
 .work-item img {
@@ -291,6 +290,10 @@ button:disabled {
   background-color: var(--color-gray);
   color: var(--color-light);
   border-radius: 4px;
+}
+
+.work-thumb {
+  position: relative;
 }
 
 .learn-btn,
@@ -311,11 +314,12 @@ button:disabled {
   top: 60%;
 }
 
-.work-item:hover .learn-btn,
-.work-item:hover .delete-btn {
+.work-thumb:hover .learn-btn,
+.work-thumb:hover .delete-btn {
   display: block;
 }
 
 .work-caption {
   margin-top: 0.5rem;
+  font-size: 0.8rem;
 }


### PR DESCRIPTION
## Summary
- Restrict "Apprendre" and "Supprimer" hover actions to appear over thumbnails only
- Shrink work title font to take less space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7138c0130832bb640ba6b07c797de