### PR TITLE
Adapt progress bar duration to API request count

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -117,7 +117,7 @@ document.getElementById('work-form').addEventListener('submit', async (e) => {
   const author = document.getElementById('work-author').value;
   const type = document.getElementById('work-type').value;
   const content = document.getElementById('work-content').value;
-  const progress = startProgress();
+  const progress = startProgress(estimateRequestCount(content));
   try {
     const res = await fetch('/works', {
       method: 'POST',

--- a/public/progress.js
+++ b/public/progress.js
@@ -1,11 +1,19 @@
-function startProgress() {
+const AVG_REQUEST_MS = 5000;
+const CHUNK_SIZE = 10000;
+
+function estimateRequestCount(text) {
+  if (!text) return 1;
+  return Math.max(1, Math.ceil(text.length / CHUNK_SIZE));
+}
+
+function startProgress(requests = 1) {
   const container = document.getElementById('analysis-progress');
   const bar = document.getElementById('progress-bar');
   const text = document.getElementById('progress-text');
   if (!container || !bar || !text) return null;
   container.classList.remove('hidden');
   bar.value = 0;
-  const ESTIMATED_MS = 10000; // 10 seconds default estimation
+  const ESTIMATED_MS = requests * AVG_REQUEST_MS;
   const start = Date.now();
   const interval = setInterval(() => {
     const elapsed = Date.now() - start;

--- a/public/works.js
+++ b/public/works.js
@@ -21,7 +21,7 @@ function renderBookResults(results) {
       const content = Array.isArray(book.first_sentence)
         ? book.first_sentence[0]
         : book.first_sentence || '';
-      const progress = startProgress();
+      const progress = startProgress(estimateRequestCount(content));
       try {
         const res = await fetch('/works', {
           method: 'POST',
@@ -85,7 +85,7 @@ function renderMovieResults(results) {
       const detail = await detailRes.json();
       const content = detail.Plot || '';
       const poster = detail.Poster && detail.Poster !== 'N/A' ? detail.Poster : undefined;
-      const progress = startProgress();
+      const progress = startProgress(estimateRequestCount(content));
       try {
         const res = await fetch('/works', {
           method: 'POST',
@@ -166,7 +166,7 @@ function renderLyricsResults(results) {
         if (!lyricRes.ok) throw new Error('Lyrics fetch failed');
         const lyricData = await lyricRes.json();
         const content = lyricData.lyrics || '';
-        const progress = startProgress();
+        const progress = startProgress(estimateRequestCount(content));
         try {
           const res = await fetch('/works', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- Estimate ChatGPT request count from text size and expose helper
- Scale progress bar duration by estimated requests instead of fixed 10s
- Update work submission flows to pass request count for accurate timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b714d51a70832bb596580f78f9e5bf