### PR TITLE
feat: add script to display prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "init-db:staging": "NODE_ENV=staging node scripts/initDb.js",
     "start": "node src/server.js",
     "start:staging": "NODE_ENV=staging PORT=4000 node src/server.js",
-    "extract-vocab": "node scripts/extract-vocab-cli.js"
+    "extract-vocab": "node scripts/extract-vocab-cli.js",
+    "show-prompt": "node scripts/show-prompt.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/show-prompt.js
+++ b/scripts/show-prompt.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Utility to display a prompt file from the prompts directory.
+
+const fs = require('fs');
+const path = require('path');
+
+const promptsDir = path.join(__dirname, '..', 'prompts');
+
+function listPrompts() {
+  return fs.readdirSync(promptsDir).filter((file) => {
+    const fullPath = path.join(promptsDir, file);
+    return fs.statSync(fullPath).isFile();
+  });
+}
+
+function showPrompt(name) {
+  let fileName = name;
+  if (!fileName.includes('.')) {
+    fileName += '.txt';
+  }
+  const filePath = path.join(promptsDir, fileName);
+  if (!fs.existsSync(filePath)) {
+    console.error(`Prompt "${fileName}" not found.`);
+    process.exit(1);
+  }
+  const content = fs.readFileSync(filePath, 'utf8');
+  console.log(content);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    const prompts = listPrompts();
+    console.log('Available prompts:');
+    for (const p of prompts) {
+      console.log(` - ${p}`);
+    }
+    console.log('\nUsage: node scripts/show-prompt.js <prompt-file>');
+    process.exit(0);
+  }
+
+  showPrompt(args[0]);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add CLI script to show prompt file contents
- expose show-prompt utility through npm scripts

## Testing
- `node scripts/show-prompt.js`
- `node scripts/show-prompt.js extract-vocabulary-en-fr`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b82bd6f16c832b9d1aed78f46bf40c