### PR TITLE
Remove parrot images from flashcards

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -18,7 +18,6 @@
   <main>
     <h2 data-i18n="vocabulary_review"></h2>
     <section id="flashcard-section" class="hidden">
-      <img src="/images/parrot_knowing.png" alt="Parrot knowing" class="flashcard-parrot parrot-left" />
       <div id="flashcard-content">
         <div id="word"></div>
         <div id="citation" class="hidden"></div>
@@ -38,7 +37,6 @@
           <p id="winner"></p>
         </div>
       </div>
-      <img src="/images/parrot_eating.png" alt="Parrot eating" class="flashcard-parrot parrot-right" />
     </section>
   </main>
   <script src="/lib/i18next/umd/i18next.min.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -120,11 +120,6 @@ button:disabled {
   flex: 1;
 }
 
-.flashcard-parrot {
-  width: 80px;
-  height: auto;
-}
-
 #word {
   font-size: 2rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- remove parrot illustrations from the flashcards page
- drop now-unused parrot styling from CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b831936254832b8243175454b49675