### PR TITLE
Align titles with their content containers

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -15,7 +15,7 @@
     </div>
     <nav id="menu" class="hidden"></nav>
   </header>
-  <h2 data-i18n="vocabulary_review"></h2>
+  <h2 class="page-title" data-i18n="vocabulary_review"></h2>
   <main>
     <section id="flashcard-section" class="hidden">
       <div id="flashcard-content">

--- a/public/settings.html
+++ b/public/settings.html
@@ -15,7 +15,7 @@
     </div>
     <nav id="menu" class="hidden"></nav>
   </header>
-  <h2 data-i18n="settings"></h2>
+  <h2 class="page-title" data-i18n="settings"></h2>
   <main>
     <p><button id="delete-account" data-i18n="delete_account"></button></p>
   </main>

--- a/public/stats.html
+++ b/public/stats.html
@@ -15,7 +15,7 @@
     </div>
     <nav id="menu" class="hidden"></nav>
   </header>
-  <h2 data-i18n="statistics"></h2>
+  <h2 class="page-title" data-i18n="statistics"></h2>
   <main>
     <p><span data-i18n="total_words_encountered"></span> <span id="total-words">0</span></p>
     <p><span data-i18n="mastered_words"></span> <span id="mastered-words">0</span></p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -63,6 +63,11 @@ main {
   box-shadow: 0 2px 8px rgba(34, 31, 31, 0.1);
 }
 
+.page-title {
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
 form {
   display: flex;
   flex-direction: column;

--- a/public/work.html
+++ b/public/work.html
@@ -15,7 +15,7 @@
     </div>
     <nav id="menu" class="hidden"></nav>
   </header>
-  <h2 id="work-title"></h2>
+  <h2 id="work-title" class="page-title"></h2>
   <main>
     <div id="work-actions">
       <button id="learn-btn" data-i18n="learn"></button>


### PR DESCRIPTION
## Summary
- Add `.page-title` style to align page titles with main content containers without nesting
- Apply the new style to flashcards, settings, stats, and work pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b846915484832bacb0cccedc6d068f