### PR TITLE
Normalize vocabulary keys case-insensitively

### DIFF
--- a/src/works.js
+++ b/src/works.js
@@ -177,22 +177,23 @@ async function extractVocabulary(text, meta = {}) {
   function mergeItems(items) {
     for (const item of items || []) {
       if (!item || !item.word) continue;
-      const word = item.word;
+      const key = item.word.toLowerCase();
       const incoming = Array.isArray(item.citations)
         ? item.citations
         : item.citation
         ? [item.citation]
         : [];
-      if (!vocabMap.has(word)) {
+      if (!vocabMap.has(key)) {
         const citations = incoming.slice(0, 3);
         const first = citations[0];
-        vocabMap.set(word, {
+        vocabMap.set(key, {
           ...item,
+          word: item.word, // preserve original casing
           citation: first ?? item.citation,
           citations,
         });
       } else {
-        const existing = vocabMap.get(word);
+        const existing = vocabMap.get(key);
         existing.citations = existing.citations || [];
         for (const cit of incoming) {
           if (

--- a/test/works.test.js
+++ b/test/works.test.js
@@ -183,4 +183,27 @@ describe('Works management', () => {
       'Yet another quill appears.',
     ]);
   });
+
+  it('merges vocabulary entries with different casing', async () => {
+    chatgpt.extractVocabularyWithLLM = async () => [
+      {
+        id: crypto.randomUUID(),
+        word: 'Serendipity',
+        definition: '',
+        citation: 'First cite',
+      },
+      {
+        id: crypto.randomUUID(),
+        word: 'serendipity',
+        definition: '',
+        citation: 'Second cite',
+      },
+    ];
+    const work = await addWork('caseUser', 'Case Work', '', 'irrelevant', 'book');
+    const entries = work.vocab.filter((v) => v.word.toLowerCase() === 'serendipity');
+    assert.strictEqual(entries.length, 1);
+    const entry = entries[0];
+    assert.strictEqual(entry.word, 'Serendipity');
+    assert.deepStrictEqual(entry.citations, ['First cite', 'Second cite']);
+  });
 });


### PR DESCRIPTION
## Summary
- deduplicate vocabulary words regardless of casing
- add regression test for mixed-case vocabulary entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b876b05368832b8a8b329510b70f83