### PR TITLE
feat: export vocabulary extractor and use in CLI

### DIFF
--- a/scripts/extract-vocab-cli.js
+++ b/scripts/extract-vocab-cli.js
@@ -3,9 +3,7 @@
 // Example: node scripts/extract-vocab-cli.js text.txt --title "Book Title" --author "Author"
 
 const fs = require('fs');
-const { extractVocabularyWithLLM } = require('../src/chatgpt');
-
-const CHUNK_SIZE = 10_000; // characters per chunk
+const { extractVocabulary } = require('../src/works');
 
 async function main() {
   if (process.argv.length < 3) {
@@ -21,29 +19,15 @@ async function main() {
       meta.title = args[++i];
     } else if (args[i] === '--author' && args[i + 1]) {
       meta.author = args[++i];
+    } else if (args[i] === '--subtitles') {
+      meta.isSubtitle = true;
     }
   }
   const text = fs.readFileSync(file, 'utf8');
 
-  const chunks = [];
-  for (let i = 0; i < text.length; i += CHUNK_SIZE) {
-    chunks.push(text.slice(i, i + CHUNK_SIZE));
-  }
-
-  const vocabMap = new Map();
-
   try {
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      console.error(`Processing chunk ${i + 1}/${chunks.length}`);
-      const items = await extractVocabularyWithLLM(chunk, undefined, meta);
-      for (const item of items) {
-        if (item && item.word && !vocabMap.has(item.word)) {
-          vocabMap.set(item.word, item);
-        }
-      }
-    }
-    const vocab = Array.from(vocabMap.values());
+    console.error('Extracting vocabulary...');
+    const vocab = await extractVocabulary(text, meta);
     console.log(JSON.stringify(vocab, null, 2));
   } catch (err) {
     console.error('Extraction failed', err.message);

--- a/src/works.js
+++ b/src/works.js
@@ -368,4 +368,12 @@ function _clearWorks() {
   works.clear();
 }
 
-module.exports = { addWork, listWorks, listAllWorks, deleteWork, deleteUserWorks, _clearWorks };
+module.exports = {
+  extractVocabulary,
+  addWork,
+  listWorks,
+  listAllWorks,
+  deleteWork,
+  deleteUserWorks,
+  _clearWorks,
+};

--- a/test/works.test.js
+++ b/test/works.test.js
@@ -15,7 +15,13 @@ chatgpt.extractVocabularyWithLLM = async (content) => {
   }));
 };
 
-const { addWork, listWorks, deleteWork, _clearWorks } = require('../src/works');
+const {
+  addWork,
+  listWorks,
+  deleteWork,
+  _clearWorks,
+  extractVocabulary,
+} = require('../src/works');
 const { getNextWord, _clear: _clearVocab } = require('../src/vocab');
 
 describe('Works management', () => {
@@ -205,5 +211,26 @@ describe('Works management', () => {
     const entry = entries[0];
     assert.strictEqual(entry.word, 'Serendipity');
     assert.deepStrictEqual(entry.citations, ['First cite', 'Second cite']);
+  });
+
+  it('exports extractVocabulary for direct use with deduplication', async () => {
+    chatgpt.extractVocabularyWithLLM = async () => [
+      {
+        id: crypto.randomUUID(),
+        word: 'Alpha',
+        definition: '',
+        citation: 'First',
+      },
+      {
+        id: crypto.randomUUID(),
+        word: 'alpha',
+        definition: '',
+        citation: 'Second',
+      },
+    ];
+    const vocab = await extractVocabulary('irrelevant', {});
+    assert.strictEqual(vocab.length, 1);
+    assert.strictEqual(vocab[0].word, 'Alpha');
+    assert.deepStrictEqual(vocab[0].citations, ['First', 'Second']);
   });
 });


### PR DESCRIPTION
## Summary
- expose `extractVocabulary` from works module with case-insensitive dedupe
- refactor `extract-vocab-cli` to use shared extractor and add subtitle flag
- add tests covering direct extractor usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87871a978832b890882da6cdf8774