### PR TITLE
Use static confetti positions away from edges

### DIFF
--- a/public/confetti.css
+++ b/public/confetti.css
@@ -1,0 +1,13 @@
+.confetti-background {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.confetti {
+  position: absolute;
+  border-radius: 2px;
+  opacity: 0.8;
+}

--- a/public/confetti.js
+++ b/public/confetti.js
@@ -4,37 +4,25 @@
   document.body.appendChild(layer);
 
   const colors = ['#ff6b6b', '#ffd93d', '#50fa7b', '#61dafb'];
-  const CONFETTI_COUNT = 40;
+  const topPositions = [10, 20, 30, 40, 50, 60, 70, 80];
+  const leftPositions = [10, 30, 50, 70, 90];
 
-  for (let i = 0; i < CONFETTI_COUNT; i++) {
+  const positions = [];
+  topPositions.forEach((top) => {
+    leftPositions.forEach((left) => {
+      positions.push({ top: `${top}%`, left: `${left}%` });
+    });
+  });
+
+  positions.forEach((pos, index) => {
     const confetti = document.createElement('div');
     confetti.className = 'confetti';
-    const size = 6 + Math.random() * 6;
-    confetti.style.width = `${size}px`;
-    confetti.style.height = `${size * 0.6}px`;
-    confetti.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
-
-    const side = Math.floor(Math.random() * 4);
-    switch (side) {
-      case 0: // left
-        confetti.style.left = '0';
-        confetti.style.top = `${Math.random() * 100}%`;
-        break;
-      case 1: // right
-        confetti.style.right = '0';
-        confetti.style.top = `${Math.random() * 100}%`;
-        break;
-      case 2: // top
-        confetti.style.top = '0';
-        confetti.style.left = `${Math.random() * 100}%`;
-        break;
-      case 3: // bottom
-        confetti.style.bottom = '0';
-        confetti.style.left = `${Math.random() * 100}%`;
-        break;
-    }
-
-    confetti.style.transform = `rotate(${Math.random() * 360}deg)`;
+    confetti.style.width = '10px';
+    confetti.style.height = '6px';
+    confetti.style.backgroundColor = colors[index % colors.length];
+    confetti.style.top = pos.top;
+    confetti.style.left = pos.left;
+    confetti.style.transform = `rotate(${(index % 8) * 45}deg)`;
     layer.appendChild(confetti);
-  }
+  });
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
   <title>Piru</title>
   <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="confetti.css" />
 </head>
 <body>
   <header>

--- a/public/styles.css
+++ b/public/styles.css
@@ -409,16 +409,3 @@ button:hover:not(:disabled) {
   color: var(--color-light);
 }
 
-.confetti-background {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  overflow: hidden;
-}
-
-.confetti {
-  position: absolute;
-  border-radius: 2px;
-  opacity: 0.8;
-}


### PR DESCRIPTION
## Summary
- stop random confetti generation and use static grid to keep confetti away from edges
- isolate confetti styles in their own stylesheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87b059304832bb8160cb78af7cb47