### PR TITLE
Improve burger menu alignment and layering

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -169,7 +169,8 @@ button:hover:not(:disabled) {
   position: relative;
   display: flex;
   align-items: center;
-  z-index: 1000;
+  margin-right: 1rem;
+  z-index: 2000;
 }
 
 .burger-button {
@@ -180,7 +181,7 @@ button:hover:not(:disabled) {
   height: 30px;
   position: relative;
   padding: 0;
-  z-index: 1001;
+  z-index: 2001;
 }
 
 .burger-button span {
@@ -229,7 +230,7 @@ button:hover:not(:disabled) {
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.5rem;
-  z-index: 1000;
+  z-index: 2000;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Add right margin to burger menu so it isn't flush with viewport edge
- Increase z-index of menu elements to ensure they stay above other containers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b87bcf3354832b97eccc14e9114f53