### PR TITLE
fix: encode userId when deleting vocabulary words

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -106,7 +106,13 @@ async function review(quality) {
 async function removeWord() {
   const userId = localStorage.getItem('userId');
   if (!currentWord) return;
-  await fetch(`/vocab/${currentWord.id}?userId=${userId}`, { method: 'DELETE' });
+  if (!userId) {
+    window.location.href = '/';
+    return;
+  }
+  await fetch(`/vocab/${currentWord.id}?userId=${encodeURIComponent(userId)}`, {
+    method: 'DELETE',
+  });
   const filter = (w) => w.id !== currentWord.id;
   seenWords = seenWords.filter(filter);
   reviewQueue = reviewQueue.filter(filter);


### PR DESCRIPTION
## Summary
- encode `userId` in remove-word request and redirect if missing

## Testing
- `npm test`
- manual `supertest` delete of vocab word returns 204

------
https://chatgpt.com/codex/tasks/task_e_68b87dc9becc832b93248ead7cc38989