### PR TITLE
Increase subtitle vocabulary batching to reduce API calls

### DIFF
--- a/scripts/test-subtitle-vocab.js
+++ b/scripts/test-subtitle-vocab.js
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const chatgpt = require('../src/chatgpt');
+const { SUBTITLE_BATCH_SIZE } = require('../src/works');
 
 // This script now uses the real OpenAI API via chatgpt.extractVocabularyWithLLM.
 // Ensure the environment variable OPENAI_API_KEY is set before running it.
@@ -21,8 +22,10 @@ async function extractFromSubtitle(filePath) {
     }
   }
   const vocabMap = new Map();
-  for (let i = 0; i < subtitles.length; i += 3) {
-    const batch = subtitles.slice(i, i + 3).join(' ');
+  for (let i = 0; i < subtitles.length; i += SUBTITLE_BATCH_SIZE) {
+    const batch = subtitles
+      .slice(i, i + SUBTITLE_BATCH_SIZE)
+      .join(' ');
     const items = await chatgpt.extractVocabularyWithLLM(batch);
     for (const item of items) {
       if (item && item.word && !vocabMap.has(item.word)) {

--- a/src/works.js
+++ b/src/works.js
@@ -22,6 +22,8 @@ const DEFAULT_THUMBNAILS = {
   custom: '/default-thumbnails/custom.svg',
 };
 
+const SUBTITLE_BATCH_SIZE = 10;
+
 function normalizeTitle(title) {
   return title
     .toLowerCase()
@@ -221,8 +223,10 @@ async function extractVocabulary(text, meta = {}) {
         if (subtitleText) subtitles.push(subtitleText);
       }
     }
-    for (let i = 0; i < subtitles.length; i += 3) {
-      const batch = subtitles.slice(i, i + 3).join(' ');
+    for (let i = 0; i < subtitles.length; i += SUBTITLE_BATCH_SIZE) {
+      const batch = subtitles
+        .slice(i, i + SUBTITLE_BATCH_SIZE)
+        .join(' ');
       const items = await chatgpt.extractVocabularyWithLLM(
         batch,
         undefined,
@@ -376,4 +380,5 @@ module.exports = {
   deleteWork,
   deleteUserWorks,
   _clearWorks,
+  SUBTITLE_BATCH_SIZE,
 };


### PR DESCRIPTION
## Summary
- export `SUBTITLE_BATCH_SIZE` from works so other modules can reuse it
- use the shared `SUBTITLE_BATCH_SIZE` in the subtitle vocabulary test script

## Testing
- `npm test`
- `npm run test-subtitle-vocab`


------
https://chatgpt.com/codex/tasks/task_e_68b880a5f5a0832b972ad9fd36df054a