### PR TITLE
Persist flashcard progress targets and cookies

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -17,6 +17,7 @@
   </header>
   <h2 class="page-title" data-i18n="vocabulary_review"></h2>
   <main>
+    <div id="progress-container"><div id="progress-bar"></div></div>
     <section id="flashcard-section" class="hidden">
       <div id="flashcard-content">
       <div id="word"></div>

--- a/public/menu.html
+++ b/public/menu.html
@@ -1,3 +1,4 @@
+<span id="cookie-count" class="cookie-counter">🍪0</span>
 <button id="menu-toggle" class="burger-button" aria-label="Menu" aria-expanded="false">
   <span></span>
   <span></span>

--- a/public/menu.js
+++ b/public/menu.js
@@ -39,9 +39,48 @@
         localStorage.removeItem('nativeLanguage');
         localStorage.removeItem('email');
         localStorage.removeItem('isAdmin');
+        localStorage.removeItem('flashcardProgress');
+        localStorage.removeItem('cookieCount');
         window.location.href = '/';
       });
     }
+
+    const cookieDisplay = menu.querySelector('#cookie-count');
+    async function renderCookies() {
+      if (cookieDisplay) {
+        const userId = localStorage.getItem('userId');
+        if (!userId) {
+          cookieDisplay.textContent = '🍪0';
+          return;
+        }
+        const res = await fetch(`/progress?userId=${userId}`);
+        if (res.ok) {
+          const data = await res.json();
+          cookieDisplay.textContent = `🍪${data.cookies}`;
+        }
+      }
+    }
+    if (cookieDisplay) {
+      cookieDisplay.addEventListener('click', async () => {
+        const userId = localStorage.getItem('userId');
+        if (!userId) return;
+        const res = await fetch(`/progress?userId=${userId}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.cookies > 0) {
+          const newCookies = data.cookies - 1;
+          await fetch('/progress', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId, progressMax: data.progressMax, cookies: newCookies }),
+          });
+          alert('Piru is happy!');
+          window.dispatchEvent(new Event('cookiechange'));
+        }
+      });
+    }
+    renderCookies();
+    window.addEventListener('cookiechange', renderCookies);
 
     const userId = localStorage.getItem('userId');
     if (!userId) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -179,6 +179,12 @@ button:hover:not(:disabled) {
   z-index: 2000;
 }
 
+.cookie-counter {
+  margin-right: 1rem;
+  cursor: pointer;
+  user-select: none;
+}
+
 .burger-button {
   background: none;
   border: none;
@@ -467,5 +473,20 @@ button:hover:not(:disabled) {
 .badge-advanced {
   background-color: var(--color-pink);
   color: var(--color-light);
+}
+
+#progress-container {
+  width: 100%;
+  height: 10px;
+  background-color: #ccc;
+  border-radius: 5px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+#progress-bar {
+  height: 100%;
+  width: 0%;
+  background-color: var(--color-yellow);
 }
 

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -6,6 +6,8 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash TEXT NOT NULL,
     native_language TEXT NOT NULL,
     is_admin INTEGER DEFAULT 0,
+    flashcard_progress_max INTEGER DEFAULT 10,
+    cookie_count INTEGER DEFAULT 0,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/src/progress.js
+++ b/src/progress.js
@@ -1,0 +1,30 @@
+const { db } = require('./db');
+
+function getProgress(userId) {
+  return new Promise((resolve, reject) => {
+    db.get(
+      'SELECT flashcard_progress_max AS progressMax, cookie_count AS cookies FROM users WHERE id = ?',
+      [userId],
+      (err, row) => {
+        if (err) return reject(err);
+        if (!row) return resolve(null);
+        resolve({ progressMax: row.progressMax, cookies: row.cookies });
+      }
+    );
+  });
+}
+
+function updateProgress(userId, progressMax, cookies) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'UPDATE users SET flashcard_progress_max = ?, cookie_count = ? WHERE id = ?',
+      [progressMax, cookies, userId],
+      (err) => {
+        if (err) return reject(err);
+        resolve();
+      }
+    );
+  });
+}
+
+module.exports = { getProgress, updateProgress };

--- a/test/db-migration.test.js
+++ b/test/db-migration.test.js
@@ -40,7 +40,13 @@ describe('Database migration', () => {
       });
     });
     const hasIsAdmin = columns.some((col) => col.name === 'is_admin');
+    const hasProgressMax = columns.some(
+      (col) => col.name === 'flashcard_progress_max'
+    );
+    const hasCookie = columns.some((col) => col.name === 'cookie_count');
     assert.strictEqual(hasIsAdmin, true);
+    assert.strictEqual(hasProgressMax, true);
+    assert.strictEqual(hasCookie, true);
     await close();
   });
 

--- a/test/progress.test.js
+++ b/test/progress.test.js
@@ -1,0 +1,45 @@
+const { describe, it, before, beforeEach } = require('node:test');
+const assert = require('assert');
+const request = require('supertest');
+
+const { init } = require('../src/db');
+const { _clearUsers } = require('../src/auth');
+let app;
+
+before(async () => {
+  await init();
+  app = require('../src/server');
+});
+
+beforeEach(async () => {
+  await _clearUsers();
+});
+
+describe('Progress API', () => {
+  it('retrieves and updates progress data', async () => {
+    const signup = await request(app)
+      .post('/auth/signup')
+      .send({
+        email: 'prog@example.com',
+        password: 'secret',
+        nativeLanguage: 'en',
+        learningLanguages: ['fr'],
+      });
+    const userId = signup.body.id;
+
+    let res = await request(app).get('/progress').query({ userId });
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.progressMax, 10);
+    assert.strictEqual(res.body.cookies, 0);
+
+    res = await request(app)
+      .post('/progress')
+      .send({ userId, progressMax: 11, cookies: 2 });
+    assert.strictEqual(res.status, 204);
+
+    res = await request(app).get('/progress').query({ userId });
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.progressMax, 11);
+    assert.strictEqual(res.body.cookies, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- Store flashcard goal length and cookie count in database with migration
- Add `/progress` API to read/update progress and expose to clients
- Update flashcard review and menu to fetch and persist progress server-side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90e04813c832bb426b85042b50dd3