### PR TITLE
feat: improve cookie counter UI

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -61,22 +61,8 @@
       }
     }
     if (cookieDisplay) {
-      cookieDisplay.addEventListener('click', async () => {
-        const userId = localStorage.getItem('userId');
-        if (!userId) return;
-        const res = await fetch(`/progress?userId=${userId}`);
-        if (!res.ok) return;
-        const data = await res.json();
-        if (data.cookies > 0) {
-          const newCookies = data.cookies - 1;
-          await fetch('/progress', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId, progressMax: data.progressMax, cookies: newCookies }),
-          });
-          alert('Piru is happy!');
-          window.dispatchEvent(new Event('cookiechange'));
-        }
+      cookieDisplay.addEventListener('click', () => {
+        alert('Révise ton vocabulaire pour gagner des cookies !');
       });
     }
     renderCookies();

--- a/public/styles.css
+++ b/public/styles.css
@@ -180,7 +180,8 @@ button:hover:not(:disabled) {
 }
 
 .cookie-counter {
-  margin-right: 1rem;
+  margin-right: 2rem;
+  font-size: 1.25rem;
   cursor: pointer;
   user-select: none;
 }


### PR DESCRIPTION
## Summary
- enlarge cookie counter and shift it left in the top menu
- show a vocabulary reminder when the cookie counter is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9118889c8832ba805d6443cf4477c