### PR TITLE
Add robust vocab deletion and client retries

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -162,9 +162,20 @@ async function removeWord() {
     window.location.href = '/';
     return;
   }
-  await fetch(`/vocab/${currentWord.id}?userId=${encodeURIComponent(userId)}`, {
-    method: 'DELETE',
-  });
+  try {
+    const res = await fetch(`/vocab/${currentWord.id}?userId=${encodeURIComponent(userId)}`, {
+      method: 'DELETE',
+    });
+    if (!res.ok) {
+      const retry = confirm('Failed to delete word. Retry?');
+      if (retry) return removeWord();
+      return;
+    }
+  } catch (err) {
+    const retry = confirm('Failed to delete word. Retry?');
+    if (retry) return removeWord();
+    return;
+  }
   const filter = (w) => w.id !== currentWord.id;
   seenWords = seenWords.filter(filter);
   reviewQueue = reviewQueue.filter(filter);

--- a/src/server.js
+++ b/src/server.js
@@ -231,7 +231,9 @@ app.delete('/vocab/:id', (req, res) => {
     return res.status(400).json({ error: 'Missing userId' });
   }
   const ok = deleteWord(userId, req.params.id);
-  if (!ok) return res.status(404).json({ error: 'Not found' });
+  if (!ok) {
+    return res.status(404).json({ error: 'User or word not found' });
+  }
   res.status(204).end();
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -188,4 +188,23 @@ describe('Vocabulary API', () => {
       .send({ userId: 'u2', wordId, quality: 4 });
     assert.strictEqual(review.status, 200);
   });
+
+  it('deletes a word', async () => {
+    await request(app)
+      .post('/vocab/extract')
+      .send({ userId: 'u3', text: 'peculiar chronicles emerge' });
+    const next = await request(app)
+      .get('/vocab/next')
+      .query({ userId: 'u3' });
+    assert.strictEqual(next.status, 200);
+    const wordId = next.body.id;
+    const del = await request(app)
+      .delete(`/vocab/${wordId}`)
+      .query({ userId: 'u3' });
+    assert.strictEqual(del.status, 204);
+    const after = await request(app)
+      .get('/vocab/next')
+      .query({ userId: 'u3' });
+    assert.strictEqual(after.status, 204);
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure `DELETE /vocab/:id` returns proper errors when user or word is missing
- Handle failed word deletions in flashcards UI with retry prompt
- Test vocabulary deletion and absence on subsequent retrieval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91448dbcc832bba2a97acbcdbdf78