### PR TITLE
Add cookie confetti background to flashcards

### DIFF
--- a/public/cookies.css
+++ b/public/cookies.css
@@ -1,0 +1,13 @@
+.cookie-background {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.cookie {
+  position: absolute;
+  background-size: contain;
+  background-repeat: no-repeat;
+}

--- a/public/cookies.js
+++ b/public/cookies.js
@@ -1,0 +1,39 @@
+(() => {
+  const layer = document.createElement('div');
+  layer.className = 'cookie-background';
+  document.body.appendChild(layer);
+
+  const cookieCount = 40;
+  const images = ['/images/cookie1.png', '/images/cookie2.png', '/images/cookie3.png'];
+
+  const halton = (index, base) => {
+    let result = 0;
+    let f = 1 / base;
+    let i = index;
+    while (i > 0) {
+      result += f * (i % base);
+      i = Math.floor(i / base);
+      f /= base;
+    }
+    return result;
+  };
+
+  for (let index = 0; index < cookieCount; index++) {
+    const cookie = document.createElement('div');
+    cookie.className = 'cookie';
+
+    const size = 20 + halton(index + 1, 5) * 40;
+    cookie.style.width = `${size}px`;
+    cookie.style.height = `${size}px`;
+
+    cookie.style.backgroundImage = `url('${images[index % images.length]}')`;
+
+    cookie.style.top = `${halton(index + 1, 2) * 100}%`;
+    cookie.style.left = `${halton(index + 1, 3) * 100}%`;
+
+    const rotation = halton(index + 1, 7) * 360;
+    cookie.style.transform = `rotate(${rotation}deg)`;
+
+    layer.appendChild(cookie);
+  }
+})();

--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Piru - Flashcards</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="cookies.css" />
 </head>
 <body>
   <header>
@@ -44,5 +45,6 @@
   <script src="i18n.js"></script>
   <script src="flashcards.js"></script>
   <script src="menu.js"></script>
+  <script src="cookies.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add cookie background CSS and JS generating 40 cookie images with Halton positioning
- include cookie assets on flashcards page

## Testing
- `npm test`
- `node src/server.js` (served and manually verified `/flashcards.html` contains new cookie assets)


------
https://chatgpt.com/codex/tasks/task_e_68b916e92400832bb7e71074b0ecf211