### PR TITLE
feat: add vocabulary game menu

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -63,7 +63,15 @@ const i18nResources = {
       winner: 'Winner:',
       waiting_for_opponent: 'Waiting for friend...',
       you: 'You',
-      friend: 'Friend'
+      friend: 'Friend',
+      select_game: 'Select a game',
+      flashcard_classic: 'Classic Flashcards',
+      flashcard_reverse: 'Reverse Flashcards',
+      quiz: 'Quiz',
+      quiz_reverse: 'Reverse Quiz',
+      unlock_for_cookie: 'Unlock for 1 cookie',
+      not_enough_cookies: 'Not enough cookies',
+      play: 'Play'
     }
   },
   fr: {
@@ -129,7 +137,15 @@ const i18nResources = {
       winner: 'Gagnant :',
       waiting_for_opponent: 'En attente de ton ami...',
       you: 'Toi',
-      friend: 'Ami'
+      friend: 'Ami',
+      select_game: 'Choisir un jeu',
+      flashcard_classic: 'Flashcard classique',
+      flashcard_reverse: 'Flashcard inversée',
+      quiz: 'Quiz',
+      quiz_reverse: 'Quiz inversé',
+      unlock_for_cookie: 'Débloquer contre 1 cookie',
+      not_enough_cookies: 'Pas assez de cookies',
+      play: 'Jouer'
     }
   },
   es: {
@@ -195,7 +211,15 @@ const i18nResources = {
       winner: 'Ganador:',
       waiting_for_opponent: 'Esperando a tu amigo...',
       you: 'Tú',
-      friend: 'Amigo'
+      friend: 'Amigo',
+      select_game: 'Elegir un juego',
+      flashcard_classic: 'Flashcards clásicas',
+      flashcard_reverse: 'Flashcards inversas',
+      quiz: 'Cuestionario',
+      quiz_reverse: 'Cuestionario inverso',
+      unlock_for_cookie: 'Desbloquear por 1 galleta',
+      not_enough_cookies: 'No hay suficientes galletas',
+      play: 'Jugar'
     }
   },
   it: {
@@ -261,7 +285,15 @@ const i18nResources = {
       winner: 'Vincitore:',
       waiting_for_opponent: "In attesa dell'amico...",
       you: 'Tu',
-      friend: 'Amico'
+      friend: 'Amico',
+      select_game: 'Scegli un gioco',
+      flashcard_classic: 'Flashcard classiche',
+      flashcard_reverse: 'Flashcard invertite',
+      quiz: 'Quiz',
+      quiz_reverse: 'Quiz inverso',
+      unlock_for_cookie: 'Sblocca per 1 biscotto',
+      not_enough_cookies: 'Biscotti insufficienti',
+      play: 'Gioca'
     }
   },
   de: {
@@ -327,7 +359,15 @@ const i18nResources = {
       winner: 'Gewinner:',
       waiting_for_opponent: 'Warte auf deinen Freund...',
       you: 'Du',
-      friend: 'Freund'
+      friend: 'Freund',
+      select_game: 'Wähle ein Spiel',
+      flashcard_classic: 'Klassische Flashcards',
+      flashcard_reverse: 'Umgekehrte Flashcards',
+      quiz: 'Quiz',
+      quiz_reverse: 'Umgekehrtes Quiz',
+      unlock_for_cookie: 'Für 1 Keks freischalten',
+      not_enough_cookies: 'Nicht genug Kekse',
+      play: 'Spielen'
     }
   }
 };

--- a/public/learn.html
+++ b/public/learn.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Piru - Learn</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="cookies.css" />
+</head>
+<body>
+  <header>
+    <a href="/"><img src="/images/parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
+    <div class="site-text">
+      <h1><a href="/" class="home-link" data-i18n="site_name">Piru</a></h1>
+      <p data-i18n="tagline">Learn foreign languages while having fun.</p>
+    </div>
+    <nav id="menu" class="hidden"></nav>
+  </header>
+  <h2 class="page-title" data-i18n="select_game"></h2>
+  <main>
+    <div id="games" class="game-list"></div>
+  </main>
+  <script src="/lib/i18next/umd/i18next.min.js"></script>
+  <script src="i18n.js"></script>
+  <script src="learn.js"></script>
+  <script src="menu.js"></script>
+  <script src="cookies.js"></script>
+</body>
+</html>

--- a/public/learn.js
+++ b/public/learn.js
@@ -1,0 +1,119 @@
+(function() {
+  const games = [
+    {
+      id: 'flashcard-classic',
+      nameKey: 'flashcard_classic',
+      link: 'flashcards.html',
+      unlocked: true
+    },
+    {
+      id: 'flashcard-reverse',
+      nameKey: 'flashcard_reverse',
+      link: 'flashcards.html?mode=reverse'
+    },
+    { id: 'quiz', nameKey: 'quiz', link: '#' },
+    { id: 'quiz-reverse', nameKey: 'quiz_reverse', link: '#' }
+  ];
+
+  let progressMax = 0;
+  let cookies = 0;
+
+  async function loadProgress() {
+    const userId = localStorage.getItem('userId');
+    if (!userId) return;
+    try {
+      const res = await fetch(`/progress?userId=${userId}`);
+      if (res.ok) {
+        const data = await res.json();
+        progressMax = data.progressMax;
+        cookies = data.cookies;
+      }
+    } catch (err) {}
+  }
+
+  function getUnlocked() {
+    try {
+      return JSON.parse(localStorage.getItem('unlockedGames') || '[]');
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveUnlocked(arr) {
+    localStorage.setItem('unlockedGames', JSON.stringify(arr));
+  }
+
+  async function unlockGame(id) {
+    if (cookies < 1) {
+      alert(i18next.t('not_enough_cookies'));
+      return;
+    }
+    cookies -= 1;
+    const userId = localStorage.getItem('userId');
+    if (userId) {
+      try {
+        await fetch('/progress', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId, progressMax, cookies })
+        });
+        window.dispatchEvent(new Event('cookiechange'));
+      } catch (err) {}
+    }
+    const unlocked = getUnlocked();
+    if (!unlocked.includes(id)) {
+      unlocked.push(id);
+      saveUnlocked(unlocked);
+    }
+    renderGames();
+  }
+
+  function renderGames() {
+    const container = document.getElementById('games');
+    if (!container) return;
+    container.innerHTML = '';
+    const unlocked = getUnlocked();
+    games.forEach((game) => {
+      const isUnlocked = game.unlocked || unlocked.includes(game.id);
+      const div = document.createElement('div');
+      div.className = 'game';
+      const span = document.createElement('span');
+      span.setAttribute('data-i18n', game.nameKey);
+      span.textContent = i18next.t(game.nameKey);
+      div.appendChild(span);
+      if (isUnlocked) {
+        const link = document.createElement('a');
+        link.href = game.link;
+        link.className = 'btn-main';
+        link.setAttribute('data-i18n', 'play');
+        link.textContent = i18next.t('play');
+        if (game.link === '#') {
+          link.addEventListener('click', (e) => {
+            e.preventDefault();
+            alert('Coming soon!');
+          });
+        }
+        div.appendChild(link);
+      } else {
+        const btn = document.createElement('button');
+        btn.className = 'btn-main';
+        btn.setAttribute('data-i18n', 'unlock_for_cookie');
+        btn.textContent = i18next.t('unlock_for_cookie');
+        btn.addEventListener('click', () => unlockGame(game.id));
+        div.appendChild(btn);
+      }
+      container.appendChild(div);
+    });
+    if (typeof updateContent === 'function') {
+      updateContent();
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    await loadProgress();
+    const defaultLang = localStorage.getItem('nativeLanguage') || 'en';
+    initI18n(defaultLang).then(() => {
+      renderGames();
+    });
+  });
+})();

--- a/public/menu.html
+++ b/public/menu.html
@@ -6,7 +6,7 @@
 </button>
 <div id="menu-options" class="hidden">
   <a id="works-link" href="/" data-i18n="my_works">My Works</a>
-  <a id="learn-link" href="flashcards.html" data-i18n="learn">Learn</a>
+  <a id="learn-link" href="learn.html" data-i18n="learn">Learn</a>
   <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>
   <a id="settings-link" href="settings.html" data-i18n="settings">Settings</a>
   <a id="logout-link" href="/" data-i18n="logout">Logout</a>

--- a/public/stats.js
+++ b/public/stats.js
@@ -15,7 +15,7 @@ async function loadStats() {
 }
 
 document.getElementById('review-vocab-button').addEventListener('click', () => {
-  window.location.href = 'flashcards.html';
+  window.location.href = 'learn.html';
 });
 
 const defaultLang = localStorage.getItem('nativeLanguage') || 'en';

--- a/public/styles.css
+++ b/public/styles.css
@@ -491,3 +491,15 @@ button:hover:not(:disabled) {
   background-color: var(--color-yellow);
 }
 
+.game-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.game {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+


### PR DESCRIPTION
## Summary
- add new learn page with unlockable vocabulary games
- link menu and stats to learn menu
- support translations and styling for new game menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b919d361dc832b8b51312307cf6dfc