### PR TITLE
feat: hoverable game cards with unlock overlay

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -143,7 +143,7 @@ const i18nResources = {
       flashcard_reverse: 'Flashcard inversée',
       quiz: 'Quiz',
       quiz_reverse: 'Quiz inversé',
-      unlock_for_cookie: 'Débloquer contre 1 cookie',
+      unlock_for_cookie: 'Débloquer : 1 cookie',
       not_enough_cookies: 'Pas assez de cookies',
       play: 'Jouer'
     }

--- a/public/learn.js
+++ b/public/learn.js
@@ -46,7 +46,7 @@
   async function unlockGame(id) {
     if (cookies < 1) {
       alert(i18next.t('not_enough_cookies'));
-      return;
+      return false;
     }
     cookies -= 1;
     const userId = localStorage.getItem('userId');
@@ -66,6 +66,7 @@
       saveUnlocked(unlocked);
     }
     renderGames();
+    return true;
   }
 
   function renderGames() {
@@ -77,31 +78,35 @@
       const isUnlocked = game.unlocked || unlocked.includes(game.id);
       const div = document.createElement('div');
       div.className = 'game';
+      div.id = game.id;
+
       const span = document.createElement('span');
       span.setAttribute('data-i18n', game.nameKey);
       span.textContent = i18next.t(game.nameKey);
       div.appendChild(span);
+
+      let hoverText = '';
       if (isUnlocked) {
-        const link = document.createElement('a');
-        link.href = game.link;
-        link.className = 'btn-main';
-        link.setAttribute('data-i18n', 'play');
-        link.textContent = i18next.t('play');
-        if (game.link === '#') {
-          link.addEventListener('click', (e) => {
-            e.preventDefault();
-            alert('Coming soon!');
-          });
-        }
-        div.appendChild(link);
+        hoverText = i18next.t('play');
       } else {
-        const btn = document.createElement('button');
-        btn.className = 'btn-main';
-        btn.setAttribute('data-i18n', 'unlock_for_cookie');
-        btn.textContent = i18next.t('unlock_for_cookie');
-        btn.addEventListener('click', () => unlockGame(game.id));
-        div.appendChild(btn);
+        hoverText = i18next.t('unlock_for_cookie');
+        div.classList.add('locked');
+        if (cookies < 1) {
+          div.classList.add('no-cookie');
+        }
       }
+      div.setAttribute('data-hover', hoverText);
+
+      div.addEventListener('click', async () => {
+        if (div.classList.contains('locked')) {
+          if (cookies < 1) return;
+          const ok = await unlockGame(game.id);
+          if (ok) window.location.href = game.link;
+        } else {
+          window.location.href = game.link;
+        }
+      });
+
       container.appendChild(div);
     });
     if (typeof updateContent === 'function') {

--- a/public/styles.css
+++ b/public/styles.css
@@ -493,13 +493,54 @@ button:hover:not(:disabled) {
 
 .game-list {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 1rem;
 }
 
 .game {
+  position: relative;
+  width: 150px;
+  height: 100px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.game span {
+  pointer-events: none;
+}
+
+.game:hover {
+  transform: scale(1.05);
+}
+
+.game::after {
+  content: attr(data-hover);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border-radius: 8px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.game:hover::after {
+  opacity: 1;
+}
+
+.game.locked.no-cookie {
+  cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary
- replace play/unlock buttons with hoverable game cards
- show unlock prompt and block click when cookies are missing
- adjust French translation for cookie unlock message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91db3de04832bb1c47a1e3973749f