### PR TITLE
feat: reposition cookie gauge and style vocabulary word

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -6,6 +6,7 @@
   <title>Piru - Flashcards</title>
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="cookies.css" />
+  <link href="https://fonts.googleapis.com/css2?family=UnifrakturMaguntia&display=swap" rel="stylesheet" />
 </head>
 <body>
   <header>
@@ -16,9 +17,11 @@
     </div>
     <nav id="menu" class="hidden"></nav>
   </header>
-  <h2 class="page-title" data-i18n="vocabulary_review"></h2>
-  <main>
+  <div class="title-row">
+    <h2 class="page-title" data-i18n="vocabulary_review"></h2>
     <div id="progress-container"><div id="progress-bar"></div></div>
+  </div>
+  <main>
     <section id="flashcard-section" class="hidden">
       <div id="flashcard-content">
       <div id="word"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -77,6 +77,23 @@ main {
   margin: 2rem auto;
 }
 
+.title-row {
+  max-width: 600px;
+  margin: 2rem auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title-row .page-title {
+  margin: 0;
+}
+
+.title-row #progress-container {
+  width: 150px;
+  margin-left: 1rem;
+}
+
 form {
   display: flex;
   flex-direction: column;
@@ -156,7 +173,10 @@ button:hover:not(:disabled) {
 
 #word {
   font-size: 2rem;
-  font-family: 'Gotham Black', 'Gotham', sans-serif;
+  font-family: 'UnifrakturMaguntia', cursive;
+  border: 2px solid #000;
+  padding: 0.5rem 1rem;
+  display: inline-block;
 }
 
 #citation {
@@ -477,12 +497,11 @@ button:hover:not(:disabled) {
 }
 
 #progress-container {
-  width: 100%;
+  width: 150px;
   height: 10px;
   background-color: #ccc;
   border-radius: 5px;
   overflow: hidden;
-  margin-bottom: 1rem;
 }
 
 #progress-bar {
@@ -490,6 +509,7 @@ button:hover:not(:disabled) {
   width: 0%;
   background-color: var(--color-yellow);
 }
+
 
 .game-list {
   display: flex;


### PR DESCRIPTION
## Summary
- Place cookie progress bar to the right of the "Révision du vocabulaire" title
- Add Gothic framing and font for displayed vocabulary words

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91f1885a8832b81ee02fe89ed92d6