### PR TITLE
Enhance game selection UI and hover messaging

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -71,6 +71,10 @@ const i18nResources = {
       quiz_reverse: 'Reverse Quiz',
       unlock_for_cookie: 'Unlock for 1 cookie',
       not_enough_cookies: 'Not enough cookies',
+      cookie_count: '{{count}} cookie',
+      cookie_count_plural: '{{count}} cookies',
+      unlock_question: 'Unlock? {{count}} cookie',
+      unlock_question_plural: 'Unlock? {{count}} cookies',
       play: 'Play'
     }
   },
@@ -145,6 +149,10 @@ const i18nResources = {
       quiz_reverse: 'Quiz inversé',
       unlock_for_cookie: 'Débloquer : 1 cookie',
       not_enough_cookies: 'Pas assez de cookies',
+      cookie_count: '{{count}} cookie',
+      cookie_count_plural: '{{count}} cookies',
+      unlock_question: 'Débloquer ? {{count}} cookie',
+      unlock_question_plural: 'Débloquer ? {{count}} cookies',
       play: 'Jouer'
     }
   },
@@ -219,6 +227,10 @@ const i18nResources = {
       quiz_reverse: 'Cuestionario inverso',
       unlock_for_cookie: 'Desbloquear por 1 galleta',
       not_enough_cookies: 'No hay suficientes galletas',
+      cookie_count: '{{count}} galleta',
+      cookie_count_plural: '{{count}} galletas',
+      unlock_question: '¿Desbloquear? {{count}} galleta',
+      unlock_question_plural: '¿Desbloquear? {{count}} galletas',
       play: 'Jugar'
     }
   },
@@ -293,6 +305,10 @@ const i18nResources = {
       quiz_reverse: 'Quiz inverso',
       unlock_for_cookie: 'Sblocca per 1 biscotto',
       not_enough_cookies: 'Biscotti insufficienti',
+      cookie_count: '{{count}} biscotto',
+      cookie_count_plural: '{{count}} biscotti',
+      unlock_question: 'Sbloccare? {{count}} biscotto',
+      unlock_question_plural: 'Sbloccare? {{count}} biscotti',
       play: 'Gioca'
     }
   },
@@ -367,6 +383,10 @@ const i18nResources = {
       quiz_reverse: 'Umgekehrtes Quiz',
       unlock_for_cookie: 'Für 1 Keks freischalten',
       not_enough_cookies: 'Nicht genug Kekse',
+      cookie_count: '{{count}} Keks',
+      cookie_count_plural: '{{count}} Kekse',
+      unlock_question: 'Freischalten? {{count}} Keks',
+      unlock_question_plural: 'Freischalten? {{count}} Kekse',
       play: 'Spielen'
     }
   }

--- a/public/learn.js
+++ b/public/learn.js
@@ -43,12 +43,12 @@
     localStorage.setItem('unlockedGames', JSON.stringify(arr));
   }
 
-  async function unlockGame(id) {
-    if (cookies < 1) {
+  async function unlockGame(id, cost = 1) {
+    if (cookies < cost) {
       alert(i18next.t('not_enough_cookies'));
       return false;
     }
-    cookies -= 1;
+    cookies -= cost;
     const userId = localStorage.getItem('userId');
     if (userId) {
       try {
@@ -76,6 +76,7 @@
     const unlocked = getUnlocked();
     games.forEach((game) => {
       const isUnlocked = game.unlocked || unlocked.includes(game.id);
+      const cost = game.cost || 1;
       const div = document.createElement('div');
       div.className = 'game';
       div.id = game.id;
@@ -89,18 +90,20 @@
       if (isUnlocked) {
         hoverText = i18next.t('play');
       } else {
-        hoverText = i18next.t('unlock_for_cookie');
         div.classList.add('locked');
-        if (cookies < 1) {
+        if (cookies < cost) {
           div.classList.add('no-cookie');
+          hoverText = i18next.t('cookie_count', { count: cost });
+        } else {
+          hoverText = i18next.t('unlock_question', { count: cost });
         }
       }
       div.setAttribute('data-hover', hoverText);
 
       div.addEventListener('click', async () => {
         if (div.classList.contains('locked')) {
-          if (cookies < 1) return;
-          const ok = await unlockGame(game.id);
+          if (cookies < cost) return;
+          const ok = await unlockGame(game.id, cost);
           if (ok) window.location.href = game.link;
         } else {
           window.location.href = game.link;

--- a/public/styles.css
+++ b/public/styles.css
@@ -500,9 +500,11 @@ button:hover:not(:disabled) {
 .game {
   position: relative;
   width: 150px;
-  height: 100px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  height: 150px;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  color: #fff;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -513,6 +515,7 @@ button:hover:not(:disabled) {
 
 .game span {
   pointer-events: none;
+  font-weight: bold;
 }
 
 .game:hover {
@@ -529,9 +532,9 @@ button:hover:not(:disabled) {
   display: flex;
   align-items: center;
   justify-content: center;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
-  border-radius: 8px;
   opacity: 0;
   transition: opacity 0.2s;
 }


### PR DESCRIPTION
## Summary
- Restyle game selection tiles with colorful hexagon shapes and shadows
- Show dynamic hover text: required cookies or unlock confirmation based on balance
- Add i18n strings for cookie counts and unlock prompts in multiple languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9206bbc64832b829e141f898ed36e