### PR TITLE
Refine flashcard word styling

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -173,10 +173,29 @@ button:hover:not(:disabled) {
 
 #word {
   font-size: 2rem;
-  font-family: 'UnifrakturMaguntia', cursive;
-  border: 2px solid #000;
   padding: 0.5rem 1rem;
   display: inline-block;
+  position: relative;
+}
+
+#word::before,
+#word::after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 12px;
+  border: 2px solid #000;
+}
+
+#word::before {
+  left: -16px;
+  border-right: none;
+}
+
+#word::after {
+  right: -16px;
+  border-left: none;
 }
 
 #citation {


### PR DESCRIPTION
## Summary
- Surround flashcard vocabulary word with subtle CSS brackets instead of fleur-de-lys decorations.

## Testing
- `npm test` *(27 passed, 0 failed, 20 cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68b920c2e98c832ba539d2a4899d5ec2