### PR TITLE
feat: show cookie marker on flashcard progress

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -19,7 +19,7 @@
   </header>
   <div class="title-row">
     <h2 class="page-title" data-i18n="vocabulary_review"></h2>
-    <div id="progress-container"><div id="progress-bar"></div></div>
+    <div id="progress-container"><div id="progress-bar"></div><div id="progress-cookie">🍪</div></div>
   </div>
   <main>
     <section id="flashcard-section" class="hidden">

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -27,9 +27,14 @@ async function loadProgress() {
 }
 
 function updateProgress() {
+  const percent = (progress / progressMax) * 100;
   const bar = document.getElementById('progress-bar');
   if (bar) {
-    bar.style.width = `${(progress / progressMax) * 100}%`;
+    bar.style.width = `${percent}%`;
+  }
+  const cookie = document.getElementById('progress-cookie');
+  if (cookie) {
+    cookie.style.left = `${percent}%`;
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -501,13 +501,22 @@ button:hover:not(:disabled) {
   height: 10px;
   background-color: #ccc;
   border-radius: 5px;
-  overflow: hidden;
+  position: relative;
+  overflow: visible;
 }
 
 #progress-bar {
   height: 100%;
   width: 0%;
   background-color: var(--color-yellow);
+}
+
+#progress-cookie {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  font-size: 1rem;
 }
 
 


### PR DESCRIPTION
## Summary
- display a small cookie icon on the flashcard progress bar to highlight current progress
- style the progress container and cookie marker
- update progress logic to position the marker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b921bc9ccc832bad3c1d1207756181