### PR TITLE
feat: add session-based authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.6.1",
         "express": "^5.1.0",
+        "express-session": "^1.18.2",
         "i18next": "^25.4.2",
         "jszip": "^3.10.1",
         "sqlite3": "^5.1.6",
@@ -852,6 +853,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -1898,6 +1939,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2055,6 +2105,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -2672,6 +2731,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "dotenv": "^16.6.1",
     "express": "^5.1.0",
+    "express-session": "^1.18.2",
     "i18next": "^25.4.2",
     "jszip": "^3.10.1",
     "sqlite3": "^5.1.6",

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,7 +1,7 @@
-const adminId = localStorage.getItem('userId');
+// Uses server-side session to identify the admin.
 
 async function loadUsers() {
-  const res = await fetch(`/admin/users?userId=${adminId}`);
+  const res = await fetch('/admin/users');
   const users = await res.json();
   const list = document.getElementById('user-list');
   list.innerHTML = '';
@@ -11,7 +11,7 @@ async function loadUsers() {
     const btn = document.createElement('button');
     btn.textContent = 'Delete';
     btn.addEventListener('click', async () => {
-      await fetch(`/admin/users/${u.id}?userId=${adminId}`, { method: 'DELETE' });
+      await fetch(`/admin/users/${u.id}`, { method: 'DELETE' });
       loadUsers();
     });
     li.appendChild(btn);
@@ -20,7 +20,7 @@ async function loadUsers() {
 }
 
 async function loadWorks() {
-  const res = await fetch(`/admin/works?userId=${adminId}`);
+  const res = await fetch('/admin/works');
   const works = await res.json();
   const list = document.getElementById('admin-work-list');
   list.innerHTML = '';
@@ -30,7 +30,7 @@ async function loadWorks() {
     const btn = document.createElement('button');
     btn.textContent = 'Delete';
     btn.addEventListener('click', async () => {
-      await fetch(`/admin/works/${w.id}?userId=${adminId}`, { method: 'DELETE' });
+      await fetch(`/admin/works/${w.id}`, { method: 'DELETE' });
       loadWorks();
     });
     li.appendChild(btn);

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-let userId = localStorage.getItem('userId');
+let userId = null;
 const storedNativeLanguage = localStorage.getItem('nativeLanguage');
 
 const nativeLanguages = [
@@ -66,7 +66,6 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
   const data = await res.json();
   if (res.ok) {
     userId = data.id;
-    localStorage.setItem('userId', userId);
     if (data.email) {
       localStorage.setItem('email', data.email);
     }
@@ -122,7 +121,7 @@ document.getElementById('work-form').addEventListener('submit', async (e) => {
     const res = await fetch('/works', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId, title, author, content, type })
+      body: JSON.stringify({ title, author, content, type })
     });
     const data = await res.json();
     if (res.ok) {
@@ -143,7 +142,8 @@ function getDifficulty(count) {
 }
 
 async function loadWorks() {
-  const res = await fetch(`/works?userId=${userId}`);
+  const res = await fetch('/works');
+  if (!res.ok) return;
   const works = await res.json();
   const container = document.getElementById('my-works-container');
   const carousel = document.getElementById('work-carousel');
@@ -245,6 +245,4 @@ function initAuthenticatedState() {
   loadWorks();
 }
 
-if (userId) {
-  initAuthenticatedState();
-}
+initAuthenticatedState();

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -13,10 +13,8 @@ let progressMax = 10;
 let cookies = 0;
 
 async function loadProgress() {
-  const userId = localStorage.getItem('userId');
-  if (!userId) return;
   try {
-    const res = await fetch(`/progress?userId=${userId}`);
+    const res = await fetch('/progress');
     if (res.ok) {
       const data = await res.json();
       progressMax = data.progressMax;
@@ -39,16 +37,11 @@ function incrementProgress() {
     progress = 0;
     progressMax += 1;
     cookies += 1;
-    const userId = localStorage.getItem('userId');
-    if (userId) {
-      fetch('/progress', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, progressMax, cookies }),
-      }).then(() => window.dispatchEvent(new Event('cookiechange')));
-    } else {
-      window.dispatchEvent(new Event('cookiechange'));
-    }
+    fetch('/progress', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ progressMax, cookies }),
+    }).then(() => window.dispatchEvent(new Event('cookiechange')));
   }
   localStorage.setItem('flashcardProgress', progress);
   updateProgress();
@@ -60,12 +53,12 @@ updateProgress();
 window.addEventListener('cookiechange', loadProgress);
 
 async function loadWorks() {
-  const userId = localStorage.getItem('userId');
-  if (!userId) return;
-  const res = await fetch(`/works?userId=${userId}`);
+  const res = await fetch('/works');
   if (res.ok) {
     const works = await res.json();
     worksById = new Map(works.map((w) => [w.id, w]));
+  } else if (res.status === 401) {
+    window.location.href = '/';
   }
 }
 
@@ -89,19 +82,13 @@ function displayWord(word) {
 }
 
 async function loadNext() {
-  const userId = localStorage.getItem('userId');
-  if (!userId) {
-    window.location.href = '/';
-    return;
-  }
-
   if (reviewQueue.length > 0) {
     currentWord = reviewQueue.shift();
     displayWord(currentWord);
     return;
   }
 
-  const res = await fetch(`/vocab/next?userId=${userId}${workId ? `&workId=${workId}` : ''}`);
+  const res = await fetch(`/vocab/next${workId ? `?workId=${workId}` : ''}`);
   if (res.status === 200) {
     currentWord = await res.json();
     if (!seenWords.find((w) => w.id === currentWord.id)) {
@@ -142,12 +129,11 @@ function showDefinition() {
 }
 
 async function review(quality) {
-  const userId = localStorage.getItem('userId');
   if (!currentWord) return;
   await fetch('/vocab/review', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, wordId: currentWord.id, quality })
+    body: JSON.stringify({ wordId: currentWord.id, quality })
   });
   if (challengeId && quality >= 4) {
     score++;
@@ -156,16 +142,15 @@ async function review(quality) {
 }
 
 async function removeWord() {
-  const userId = localStorage.getItem('userId');
   if (!currentWord) return;
-  if (!userId) {
-    window.location.href = '/';
-    return;
-  }
   try {
-    const res = await fetch(`/vocab/${currentWord.id}?userId=${encodeURIComponent(userId)}`, {
+    const res = await fetch(`/vocab/${currentWord.id}`, {
       method: 'DELETE',
     });
+    if (res.status === 401) {
+      window.location.href = '/';
+      return;
+    }
     if (!res.ok) {
       const retry = confirm('Failed to delete word. Retry?');
       if (retry) return removeWord();
@@ -192,23 +177,21 @@ document.getElementById('add-work-btn').addEventListener('click', () => {
 });
 
 async function finishChallenge() {
-  const userId = localStorage.getItem('userId');
   const res = await fetch(`/challenges/${challengeId}/score`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, score })
+    body: JSON.stringify({ score })
   });
   if (res.ok) {
     const data = await fetch(`/challenges/${challengeId}`);
     if (data.ok) {
       const result = await data.json();
-      const me = result.scores.find((s) => s.userId === userId);
-      const other = result.scores.find((s) => s.userId !== userId);
+      const [me, other] = result.scores;
       document.getElementById('your-score').textContent = `${i18next.t('your_score')} ${me ? me.score : 0}`;
       document.getElementById('opponent-score').textContent = `${i18next.t('opponent_score')} ${other && typeof other.score === 'number' ? other.score : '-'}`;
       const winnerEl = document.getElementById('winner');
       if (result.winner) {
-        winnerEl.textContent = i18next.t('winner') + ' ' + (result.winner === userId ? i18next.t('you') : i18next.t('friend'));
+        winnerEl.textContent = i18next.t('winner') + ' ' + result.winner;
       } else {
         winnerEl.textContent = i18next.t('waiting_for_opponent');
       }

--- a/public/learn.js
+++ b/public/learn.js
@@ -19,10 +19,8 @@
   let cookies = 0;
 
   async function loadProgress() {
-    const userId = localStorage.getItem('userId');
-    if (!userId) return;
     try {
-      const res = await fetch(`/progress?userId=${userId}`);
+      const res = await fetch('/progress');
       if (res.ok) {
         const data = await res.json();
         progressMax = data.progressMax;
@@ -49,17 +47,14 @@
       return false;
     }
     cookies -= 1;
-    const userId = localStorage.getItem('userId');
-    if (userId) {
-      try {
-        await fetch('/progress', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId, progressMax, cookies })
-        });
-        window.dispatchEvent(new Event('cookiechange'));
-      } catch (err) {}
-    }
+    try {
+      await fetch('/progress', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ progressMax, cookies })
+      });
+      window.dispatchEvent(new Event('cookiechange'));
+    } catch (err) {}
     const unlocked = getUnlocked();
     if (!unlocked.includes(id)) {
       unlocked.push(id);

--- a/public/menu.js
+++ b/public/menu.js
@@ -33,9 +33,11 @@
 
     const logoutLink = menu.querySelector('#logout-link');
     if (logoutLink) {
-      logoutLink.addEventListener('click', (e) => {
+      logoutLink.addEventListener('click', async (e) => {
         e.preventDefault();
-        localStorage.removeItem('userId');
+        try {
+          await fetch('/logout', { method: 'POST' });
+        } catch (err) {}
         localStorage.removeItem('nativeLanguage');
         localStorage.removeItem('email');
         localStorage.removeItem('isAdmin');
@@ -48,15 +50,12 @@
     const cookieDisplay = menu.querySelector('#cookie-count');
     async function renderCookies() {
       if (cookieDisplay) {
-        const userId = localStorage.getItem('userId');
-        if (!userId) {
-          cookieDisplay.textContent = '🍪0';
-          return;
-        }
-        const res = await fetch(`/progress?userId=${userId}`);
+        const res = await fetch('/progress');
         if (res.ok) {
           const data = await res.json();
           cookieDisplay.textContent = `🍪${data.cookies}`;
+        } else {
+          cookieDisplay.textContent = '🍪0';
         }
       }
     }
@@ -68,12 +67,8 @@
     renderCookies();
     window.addEventListener('cookiechange', renderCookies);
 
-    const userId = localStorage.getItem('userId');
-    if (!userId) {
-      menu.classList.add('hidden');
-    } else {
-      menu.classList.remove('hidden');
-    }
+    // Show menu by default; server-side session determines access.
+    menu.classList.remove('hidden');
   }
 
   document.addEventListener('DOMContentLoaded', loadMenu);

--- a/public/settings.js
+++ b/public/settings.js
@@ -3,14 +3,8 @@
   if (btn) {
     btn.addEventListener('click', async () => {
       if (!confirm(i18next.t('confirm_delete_account'))) return;
-      const userId = localStorage.getItem('userId');
-      if (!userId) {
-        window.location.href = '/';
-        return;
-      }
-      const res = await fetch(`/auth/account?userId=${userId}`, { method: 'DELETE' });
+      const res = await fetch('/auth/account', { method: 'DELETE' });
       if (res.ok) {
-        localStorage.removeItem('userId');
         localStorage.removeItem('nativeLanguage');
         localStorage.removeItem('email');
         localStorage.removeItem('isAdmin');

--- a/public/stats.js
+++ b/public/stats.js
@@ -1,16 +1,13 @@
 (function() {
 
 async function loadStats() {
-  const userId = localStorage.getItem('userId');
-  if (!userId) {
-    window.location.href = '/';
-    return;
-  }
-  const res = await fetch(`/stats/overview?userId=${userId}`);
+  const res = await fetch('/stats/overview');
   if (res.ok) {
     const data = await res.json();
     document.getElementById('total-words').textContent = data.totalWords;
     document.getElementById('mastered-words').textContent = data.masteredWords;
+  } else if (res.status === 401) {
+    window.location.href = '/';
   }
 }
 

--- a/public/work.js
+++ b/public/work.js
@@ -1,14 +1,17 @@
 (function() {
 const params = new URLSearchParams(window.location.search);
 const workId = params.get('workId');
-const userId = localStorage.getItem('userId');
-if (!userId || !workId) {
+if (!workId) {
   window.location.href = '/';
   return;
 }
 
 async function loadWork() {
-  const res = await fetch(`/works?userId=${userId}`);
+  const res = await fetch('/works');
+  if (!res.ok) {
+    window.location.href = '/';
+    return;
+  }
   const works = await res.json();
   const work = works.find(w => w.id === workId);
   if (!work) {
@@ -33,7 +36,7 @@ document.getElementById('learn-btn').addEventListener('click', () => {
 
 document.getElementById('delete-btn').addEventListener('click', async () => {
   if (!confirm(i18next.t('confirm_delete_work'))) return;
-  const res = await fetch(`/works/${encodeURIComponent(workId)}?userId=${userId}`, { method: 'DELETE' });
+  const res = await fetch(`/works/${encodeURIComponent(workId)}`, { method: 'DELETE' });
   if (res.ok) {
     window.location.href = '/';
   }
@@ -43,7 +46,7 @@ document.getElementById('challenge-btn').addEventListener('click', async () => {
   const res = await fetch('/challenges', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ userId, workId })
+    body: JSON.stringify({ workId })
   });
   if (res.ok) {
     const data = await res.json();

--- a/public/works.js
+++ b/public/works.js
@@ -26,7 +26,7 @@ function renderBookResults(results) {
         const res = await fetch('/works', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId, title, author, content, type: 'book' })
+          body: JSON.stringify({ title, author, content, type: 'book' })
         });
         if (res.ok) {
           loadWorks();
@@ -90,7 +90,7 @@ function renderMovieResults(results) {
         const res = await fetch('/works', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId, title: detail.Title, author: '', content, type, thumbnail: poster })
+          body: JSON.stringify({ title: detail.Title, author: '', content, type, thumbnail: poster })
         });
         if (res.ok) {
           loadWorks();
@@ -172,7 +172,6 @@ function renderLyricsResults(results) {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              userId,
               title: song.title,
               author: song.artist.name,
               content,

--- a/test/challenges.test.js
+++ b/test/challenges.test.js
@@ -22,6 +22,19 @@ before(async () => {
   app = require('../src/server');
 });
 
+async function signupAndLogin(email) {
+  const agent = request.agent(app);
+  const password = 'secret';
+  const signupRes = await agent.post('/auth/signup').send({
+    email,
+    password,
+    nativeLanguage: 'en',
+    learningLanguages: ['fr'],
+  });
+  await agent.post('/auth/login').send({ email, password });
+  return { agent, userId: signupRes.body.id };
+}
+
 describe('Challenges API', () => {
   beforeEach(() => {
     _clearWorks();
@@ -30,30 +43,32 @@ describe('Challenges API', () => {
   });
 
   it('creates a challenge and determines winner', async () => {
-    await request(app)
+    const { agent: agent1, userId: user1Id } = await signupAndLogin('u1@example.com');
+    const { agent: agent2, userId: user2Id } = await signupAndLogin('u2@example.com');
+    await agent1
       .post('/works')
-      .send({ userId: 'u1', title: 'W', author: 'A', content: 'text', type: 'book' });
-    const list = await request(app).get('/works').query({ userId: 'u1' });
+      .send({ title: 'W', author: 'A', content: 'text', type: 'book' });
+    const list = await agent1.get('/works');
     const workId = list.body[0].id;
-    const createRes = await request(app)
+    const createRes = await agent1
       .post('/challenges')
-      .send({ userId: 'u1', workId });
+      .send({ workId });
     assert.strictEqual(createRes.status, 201);
     const challengeId = createRes.body.id;
     assert.ok(challengeId);
 
-    let res = await request(app)
+    let res = await agent1
       .post(`/challenges/${challengeId}/score`)
-      .send({ userId: 'u1', score: 3 });
+      .send({ score: 3 });
     assert.strictEqual(res.status, 200);
 
-    res = await request(app)
+    res = await agent2
       .post(`/challenges/${challengeId}/score`)
-      .send({ userId: 'u2', score: 5 });
+      .send({ score: 5 });
     assert.strictEqual(res.status, 200);
 
     const final = await request(app).get(`/challenges/${challengeId}`);
     assert.strictEqual(final.status, 200);
-    assert.strictEqual(final.body.winner, 'u2');
+    assert.strictEqual(final.body.winner, user2Id);
   });
 });

--- a/test/progress.test.js
+++ b/test/progress.test.js
@@ -17,7 +17,8 @@ beforeEach(async () => {
 
 describe('Progress API', () => {
   it('retrieves and updates progress data', async () => {
-    const signup = await request(app)
+    const agent = request.agent(app);
+    await agent
       .post('/auth/signup')
       .send({
         email: 'prog@example.com',
@@ -25,19 +26,22 @@ describe('Progress API', () => {
         nativeLanguage: 'en',
         learningLanguages: ['fr'],
       });
-    const userId = signup.body.id;
+    await agent.post('/auth/login').send({
+      email: 'prog@example.com',
+      password: 'secret',
+    });
 
-    let res = await request(app).get('/progress').query({ userId });
+    let res = await agent.get('/progress');
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.body.progressMax, 10);
     assert.strictEqual(res.body.cookies, 0);
 
-    res = await request(app)
+    res = await agent
       .post('/progress')
-      .send({ userId, progressMax: 11, cookies: 2 });
+      .send({ progressMax: 11, cookies: 2 });
     assert.strictEqual(res.status, 204);
 
-    res = await request(app).get('/progress').query({ userId });
+    res = await agent.get('/progress');
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.body.progressMax, 11);
     assert.strictEqual(res.body.cookies, 2);


### PR DESCRIPTION
## Summary
- use express-session middleware to persist authenticated user id
- secure progress, works, vocab, admin, and challenge routes via session
- update client scripts to drop userId query parameters and rely on session

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b920d8cedc832b9d5517e4b6386a01