### PR TITLE
Check auth before rendering works page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -245,4 +245,15 @@ function initAuthenticatedState() {
   loadWorks();
 }
 
-initAuthenticatedState();
+async function checkAuthState() {
+  try {
+    const res = await fetch('/progress');
+    if (res.ok) {
+      initAuthenticatedState();
+    }
+  } catch (err) {
+    // ignore network errors
+  }
+}
+
+checkAuthState();


### PR DESCRIPTION
## Summary
- Only show add-work interface after verifying an authenticated session
- Keep login visible when not authenticated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b923a4dd10832bb6ccd215899b52b9