### PR TITLE
Style game tiles with rectangular blue/gray containers and shape icons

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -4,15 +4,17 @@
       id: 'flashcard-classic',
       nameKey: 'flashcard_classic',
       link: 'flashcards.html',
-      unlocked: true
+      unlocked: true,
+      shape: 'square'
     },
     {
       id: 'flashcard-reverse',
       nameKey: 'flashcard_reverse',
-      link: 'flashcards.html?mode=reverse'
+      link: 'flashcards.html?mode=reverse',
+      shape: 'diamond'
     },
-    { id: 'quiz', nameKey: 'quiz', link: '#' },
-    { id: 'quiz-reverse', nameKey: 'quiz_reverse', link: '#' }
+    { id: 'quiz', nameKey: 'quiz', link: '#', shape: 'circle' },
+    { id: 'quiz-reverse', nameKey: 'quiz_reverse', link: '#', shape: 'triangle' }
   ];
 
   let progressMax = 0;
@@ -80,6 +82,10 @@
       span.setAttribute('data-i18n', game.nameKey);
       span.textContent = i18next.t(game.nameKey);
       div.appendChild(span);
+
+      const shape = document.createElement('div');
+      shape.className = `identifier ${game.shape || ''}`;
+      div.appendChild(shape);
 
       let hoverText = '';
       if (isUnlocked) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -547,13 +547,14 @@ button:hover:not(:disabled) {
 
 .game {
   position: relative;
-  width: 150px;
-  height: 150px;
-  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
-  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  width: 200px;
+  height: 120px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #4a90e2, #9aa5b1);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
   color: #fff;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
@@ -564,6 +565,38 @@ button:hover:not(:disabled) {
 .game span {
   pointer-events: none;
   font-weight: bold;
+}
+
+.game .identifier {
+  margin-top: 0.5rem;
+}
+
+.game .identifier.square {
+  width: 20px;
+  height: 20px;
+  background: #fff;
+}
+
+.game .identifier.diamond {
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  transform: rotate(45deg);
+}
+
+.game .identifier.circle {
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  border-radius: 50%;
+}
+
+.game .identifier.triangle {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid #fff;
 }
 
 .game:hover {
@@ -580,7 +613,7 @@ button:hover:not(:disabled) {
   display: flex;
   align-items: center;
   justify-content: center;
-  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  border-radius: 10px;
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   opacity: 0;


### PR DESCRIPTION
## Summary
- add shape metadata to games and render a shape icon under each title
- restyle game containers as rounded rectangles in a blue/gray palette
- include CSS for square, diamond, circle and triangle identifiers

## Testing
- `npm test` *(fails: Cannot find module 'express-session')*

------
https://chatgpt.com/codex/tasks/task_e_68b926379ad0832bafe113f968905867