### PR TITLE
Handle non-JSON requests in server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,14 @@ const { getProgress, updateProgress } = require('./progress');
 const { createChallenge, submitScore, getChallenge } = require('./challenges');
 
 const app = express();
-app.use(express.json());
+// Only parse JSON bodies for non-GET/HEAD requests that declare a JSON payload.
+const jsonParser = express.json();
+app.use((req, res, next) => {
+  if (req.method === 'GET' || req.method === 'HEAD' || !req.is('application/json')) {
+    return next();
+  }
+  return jsonParser(req, res, next);
+});
 app.use(
   session({
     secret: process.env.SESSION_SECRET || 'dev-secret',

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -125,6 +125,11 @@ describe('Works API', () => {
     _clearVocab();
   });
 
+  it('requires authentication to list works', async () => {
+    const res = await request(app).get('/works');
+    assert.strictEqual(res.status, 401);
+  });
+
   it('creates a work', async () => {
     const { agent } = await signupAndLogin('user1@example.com');
     const res = await agent


### PR DESCRIPTION
## Summary
- Skip express.json for GET/HEAD or requests missing `Content-Type: application/json`
- Add test ensuring GET /works requires authentication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9281ea620832b948777e31ed7bc18