### PR TITLE
Avoid progress requests for anonymous users

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -246,6 +246,10 @@ function initAuthenticatedState() {
 }
 
 async function checkAuthState() {
+  // Avoid hitting the progress endpoint when the user is not logged in.
+  if (!localStorage.getItem('email')) {
+    return;
+  }
   try {
     const res = await fetch('/progress');
     if (res.ok) {

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -13,6 +13,11 @@ let progressMax = 10;
 let cookies = 0;
 
 async function loadProgress() {
+  // Only fetch progress if the user is logged in.
+  if (!localStorage.getItem('email')) {
+    updateProgress();
+    return;
+  }
   try {
     const res = await fetch('/progress');
     if (res.ok) {

--- a/public/learn.js
+++ b/public/learn.js
@@ -21,6 +21,10 @@
   let cookies = 0;
 
   async function loadProgress() {
+    // Prevent unauthenticated users from hitting the progress endpoint.
+    if (!localStorage.getItem('email')) {
+      return;
+    }
     try {
       const res = await fetch('/progress');
       if (res.ok) {

--- a/public/menu.js
+++ b/public/menu.js
@@ -49,14 +49,20 @@
 
     const cookieDisplay = menu.querySelector('#cookie-count');
     async function renderCookies() {
-      if (cookieDisplay) {
-        const res = await fetch('/progress');
-        if (res.ok) {
-          const data = await res.json();
-          cookieDisplay.textContent = `🍪${data.cookies}`;
-        } else {
-          cookieDisplay.textContent = '🍪0';
-        }
+      if (!cookieDisplay) {
+        return;
+      }
+      // Skip the progress request entirely for anonymous users.
+      if (!localStorage.getItem('email')) {
+        cookieDisplay.textContent = '🍪0';
+        return;
+      }
+      const res = await fetch('/progress');
+      if (res.ok) {
+        const data = await res.json();
+        cookieDisplay.textContent = `🍪${data.cookies}`;
+      } else {
+        cookieDisplay.textContent = '🍪0';
       }
     }
     if (cookieDisplay) {


### PR DESCRIPTION
## Summary
- Prevent progress fetch from running without a stored login in app.js
- Skip progress requests in menu and game pages when email absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9294c6a84832ba3019888a37b6b41