### PR TITLE
fix: persist sqlite database across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Initialize the local SQLite database (creates tables if they don't exist):
 npm run init-db
 ```
 
+The database file is stored in the project root by default. To keep it in a
+different location, set the `PIRU_DB_DIR` environment variable before running
+any commands.
+
 ### Vocabulary extraction CLI
 
 Extract difficult vocabulary from a text file or large subtitle. The CLI will

--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -2,10 +2,12 @@ const fs = require('fs');
 const path = require('path');
 
 const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
-// Use the current working directory for the SQLite database so that the
-// initialization script works even when the project files are installed in a
-// read-only location (for example when Piru is installed globally).
-const dbPath = path.join(process.cwd(), dbFile);
+// Use the same location strategy as the main application so that the
+// initialization script operates on the correct database regardless of where
+// it is executed from. The directory can be overridden with `PIRU_DB_DIR`.
+const dbDir = process.env.PIRU_DB_DIR || path.resolve(__dirname, '..');
+if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
+const dbPath = path.join(dbDir, dbFile);
 
 if (process.env.NODE_ENV === 'test' && fs.existsSync(dbPath)) {
   fs.unlinkSync(dbPath);

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -3,13 +3,13 @@ const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 
 const dbFile = process.env.NODE_ENV === 'staging' ? 'piru-staging.sqlite' : 'piru.sqlite';
-// Store the SQLite database in the current working directory instead of the
-// module directory. When Piru is installed as a dependency or run globally,
-// the module directory may be read-only, which would prevent SQLite from
-// creating or writing to the database file and result in a SQLITE_READONLY
-// error. Using `process.cwd()` ensures the database lives in a writable
-// location for the running user.
-const dbPath = path.join(process.cwd(), dbFile);
+// Store the SQLite database in a predictable location so that data persists
+// regardless of where the server is started from. The directory can be
+// overridden with the `PIRU_DB_DIR` environment variable. By default we use
+// the project root.
+const dbDir = process.env.PIRU_DB_DIR || path.resolve(__dirname, '..', '..');
+if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
+const dbPath = path.join(dbDir, dbFile);
 
 const db = new sqlite3.Database(dbPath);
 

--- a/test/db-path.test.js
+++ b/test/db-path.test.js
@@ -1,0 +1,27 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const path = require('path');
+
+const authPath = path.resolve(__dirname, '../src/auth.js');
+const dbPath = path.resolve(__dirname, '../src/db/index.js');
+
+test('database persists across cwd changes', async () => {
+  const { signup } = require(authPath);
+  const { close } = require(dbPath);
+
+  await signup('persist@example.com', 'secret', 'fr', ['en']);
+  await close();
+
+  const originalCwd = process.cwd();
+  process.chdir(path.join(originalCwd, 'src'));
+  delete require.cache[authPath];
+  delete require.cache[dbPath];
+
+  const { login, _clearUsers } = require(authPath);
+  const user = await login('persist@example.com', 'secret');
+  assert.strictEqual(user.email, 'persist@example.com');
+
+  await _clearUsers();
+  await require(dbPath).close();
+  process.chdir(originalCwd);
+});


### PR DESCRIPTION
## Summary
- store SQLite database in stable directory and allow override via `PIRU_DB_DIR`
- align init script with database path
- document DB directory option and add regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92ac6daf0832bb46f62dfc48fd99c