### PR TITLE
Hide menu and cookie counter for anonymous users

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -10,7 +10,9 @@
         if (typeof updateContent === 'function') {
           updateContent();
         }
-        setupMenu(menu);
+        if (localStorage.getItem('email')) {
+          setupMenu(menu);
+        }
       })
       .catch((err) => console.error('Failed to load menu:', err));
   }
@@ -52,17 +54,22 @@
       if (!cookieDisplay) {
         return;
       }
-      // Skip the progress request entirely for anonymous users.
+      // Hide the counter for anonymous users.
       if (!localStorage.getItem('email')) {
-        cookieDisplay.textContent = '🍪0';
+        cookieDisplay.classList.add('hidden');
         return;
       }
-      const res = await fetch('/progress');
-      if (res.ok) {
-        const data = await res.json();
-        cookieDisplay.textContent = `🍪${data.cookies}`;
-      } else {
-        cookieDisplay.textContent = '🍪0';
+      try {
+        const res = await fetch('/progress');
+        if (res.ok) {
+          const data = await res.json();
+          cookieDisplay.textContent = `🍪${data.cookies}`;
+          cookieDisplay.classList.remove('hidden');
+        } else {
+          cookieDisplay.classList.add('hidden');
+        }
+      } catch {
+        cookieDisplay.classList.add('hidden');
       }
     }
     if (cookieDisplay) {


### PR DESCRIPTION
## Summary
- Only initialize burger menu for logged-in users
- Hide cookie counter when no user session is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b931262bd8832ba035d360da11a324