### PR TITLE
Avoid login flicker for authenticated users

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -246,17 +246,21 @@ function initAuthenticatedState() {
 }
 
 async function checkAuthState() {
-  // Avoid hitting the progress endpoint when the user is not logged in.
+  const authSection = document.getElementById('auth');
+  // Show the login form immediately if no email is stored.
   if (!localStorage.getItem('email')) {
+    authSection.classList.remove('hidden');
     return;
   }
   try {
     const res = await fetch('/progress');
     if (res.ok) {
       initAuthenticatedState();
+    } else {
+      authSection.classList.remove('hidden');
     }
   } catch (err) {
-    // ignore network errors
+    authSection.classList.remove('hidden');
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
     <nav id="menu" class="hidden"></nav>
   </header>
   <main>
-    <section id="auth">
+    <section id="auth" class="hidden">
       <h2 data-i18n="login">Login</h2>
       <form id="login-form">
         <input type="email" id="login-email" data-i18n-placeholder="email" placeholder="Email" required />


### PR DESCRIPTION
## Summary
- Hide login section by default to prevent flash when users return to the main page while already logged in
- Expand authentication check to show login only when no session is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b931727f20832b8c0637e4a49ca2ab