### PR TITLE
fix: ensure background cookies stay behind content

### DIFF
--- a/public/cookies.css
+++ b/public/cookies.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 0;
+  z-index: -1;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- position background cookies beneath page elements by lowering z-index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b931b268f8832bab24fda55b22761e