### PR TITLE
Add subtitle vocabulary navigation for film works

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -628,3 +628,44 @@ button:hover:not(:disabled) {
   cursor: not-allowed;
 }
 
+#subtitle-nav {
+  margin-top: 1rem;
+}
+
+#subtitle-scale {
+  position: relative;
+  height: 20px;
+  background-color: var(--color-light);
+  margin-bottom: 0.5rem;
+}
+
+#subtitle-scale .tick {
+  position: absolute;
+  bottom: 0;
+  width: 2px;
+  background-color: var(--color-gray);
+}
+
+#subtitle-scale .tick.big {
+  height: 12px;
+}
+
+#subtitle-scale .tick.small {
+  height: 6px;
+}
+
+#subtitle-progress-marker {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  background-color: var(--color-pink);
+}
+
+#subtitle-word-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+

--- a/public/work.html
+++ b/public/work.html
@@ -32,6 +32,14 @@
       <p data-i18n="challenge_link"></p>
       <input id="challenge-link" readonly />
     </div>
+    <div id="subtitle-nav" class="hidden">
+      <div id="subtitle-scale"></div>
+      <div id="subtitle-word-nav">
+        <button id="prev-word">&#9664;</button>
+        <span id="subtitle-current-word"></span>
+        <button id="next-word">&#9654;</button>
+      </div>
+    </div>
   </main>
   <script src="/lib/i18next/umd/i18next.min.js"></script>
   <script src="i18n.js"></script>

--- a/public/work.js
+++ b/public/work.js
@@ -6,6 +6,46 @@ if (!workId) {
   return;
 }
 
+function initSubtitleNav(work) {
+  if (work.type !== 'movie' && work.type !== 'series') return;
+  const vocab = work.vocab || [];
+  if (!vocab.length) return;
+  const nav = document.getElementById('subtitle-nav');
+  nav.classList.remove('hidden');
+  const scale = document.getElementById('subtitle-scale');
+  scale.innerHTML = '';
+  const duration = vocab.length * 5; // fake minutes
+  for (let m = 0; m <= duration; m += 5) {
+    const tick = document.createElement('div');
+    tick.className = 'tick ' + (m % 60 === 0 ? 'big' : 'small');
+    tick.style.left = `${(m / duration) * 100}%`;
+    scale.appendChild(tick);
+  }
+  const marker = document.createElement('div');
+  marker.id = 'subtitle-progress-marker';
+  scale.appendChild(marker);
+  let index = 0;
+  const wordSpan = document.getElementById('subtitle-current-word');
+  function update() {
+    const entry = vocab[index];
+    wordSpan.textContent = entry ? entry.word : '';
+    marker.style.left = `${((index * 5) / duration) * 100}%`;
+  }
+  document.getElementById('prev-word').addEventListener('click', () => {
+    if (index > 0) {
+      index--;
+      update();
+    }
+  });
+  document.getElementById('next-word').addEventListener('click', () => {
+    if (index < vocab.length - 1) {
+      index++;
+      update();
+    }
+  });
+  update();
+}
+
 async function loadWork() {
   const res = await fetch('/works');
   if (!res.ok) {
@@ -28,6 +68,7 @@ async function loadWork() {
   const learned = work.learnedCount || 0;
   const percent = total ? Math.round((learned / total) * 100) : 0;
   document.getElementById('vocab-stats').textContent = `${total} mots de vocabulaire – ${learned} appris (${percent}%)`;
+  initSubtitleNav(work);
 }
 
 document.getElementById('learn-btn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- show subtitle vocabulary navigation with timeline and word controls on work page
- add script to manage timeline ticks and word navigation for movies and series
- style subtitle timeline and navigation controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b933325270832b967f4ae126794c2c