### PR TITLE
Adjust game selection layout and hover effects

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -91,19 +91,17 @@
       shape.className = `identifier ${game.shape || ''}`;
       div.appendChild(shape);
 
-      let hoverText = '';
       if (isUnlocked) {
-        hoverText = i18next.t('play');
+        div.classList.add('unlocked');
       } else {
         div.classList.add('locked');
         if (cookies < cost) {
           div.classList.add('no-cookie');
-          hoverText = i18next.t('cookie_count', { count: cost });
+          div.setAttribute('data-hover', i18next.t('cookie_count', { count: cost }));
         } else {
-          hoverText = i18next.t('unlock_question', { count: cost });
+          div.setAttribute('data-hover', i18next.t('unlock_question', { count: cost }));
         }
       }
-      div.setAttribute('data-hover', hoverText);
 
       div.addEventListener('click', async () => {
         if (div.classList.contains('locked')) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -541,13 +541,13 @@ button:hover:not(:disabled) {
 
 .game-list {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 1rem;
 }
 
 .game {
   position: relative;
-  width: 200px;
+  width: 100%;
   height: 120px;
   border-radius: 10px;
   background: linear-gradient(135deg, #4a90e2, #9aa5b1);
@@ -565,10 +565,12 @@ button:hover:not(:disabled) {
 .game span {
   pointer-events: none;
   font-weight: bold;
+  transition: color 0.2s, text-shadow 0.2s;
 }
 
 .game .identifier {
   margin-top: 0.5rem;
+  transition: background 0.2s, border-color 0.2s;
 }
 
 .game .identifier.square {
@@ -603,7 +605,7 @@ button:hover:not(:disabled) {
   transform: scale(1.05);
 }
 
-.game::after {
+.game.locked::after {
   content: attr(data-hover);
   position: absolute;
   top: 0;
@@ -620,8 +622,21 @@ button:hover:not(:disabled) {
   transition: opacity 0.2s;
 }
 
-.game:hover::after {
+.game.locked:hover::after {
   opacity: 1;
+}
+
+.game.unlocked:hover span {
+  color: #ffd700;
+  text-shadow: 1px 1px 2px #000;
+}
+
+.game.unlocked:hover .identifier {
+  background: #ffd700;
+}
+
+.game.unlocked:hover .identifier.triangle {
+  border-bottom-color: #ffd700;
 }
 
 .game.locked.no-cookie {


### PR DESCRIPTION
## Summary
- Make game cards span the full width of the selection container
- Replace play overlay with golden hover styling for unlocked games

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b936424dd4832ba4dd9908d6f64fe7