### PR TITLE
Simplify flashcard word display

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -172,30 +172,8 @@ button:hover:not(:disabled) {
 }
 
 #word {
-  font-size: 2rem;
-  padding: 0.5rem 1rem;
-  display: inline-block;
-  position: relative;
-}
-
-#word::before,
-#word::after {
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  width: 12px;
-  border: 2px solid #000;
-}
-
-#word::before {
-  left: -16px;
-  border-right: none;
-}
-
-#word::after {
-  right: -16px;
-  border-left: none;
+  font-size: 3rem;
+  font-weight: bold;
 }
 
 #citation {


### PR DESCRIPTION
## Summary
- Remove decorative border from flashcard word and display it bold and larger for clarity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93741d9c4832b8ef7d6b2afea1cd8