### PR TITLE
Style citations with quotes and colors

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -72,9 +72,13 @@ async function loadWorks() {
 }
 
 function formatCitation(text) {
+  if (!text) {
+    return '';
+  }
   const div = document.createElement('div');
-  div.textContent = text || '';
-  return div.innerHTML.replace(/\*(.*?)\*/g, '<strong>$1</strong>');
+  div.textContent = text;
+  const html = div.innerHTML.replace(/\*(.*?)\*/g, '<strong>$1</strong>');
+  return `"${html}"`;
 }
 
 function displayWord(word) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -179,12 +179,13 @@ button:hover:not(:disabled) {
 #citation {
   font-style: italic;
   text-align: left;
+  color: var(--color-dark);
 }
 
 #citation-source {
   font-style: italic;
   text-align: right;
-  color: #555;
+  color: var(--color-gray);
 }
 
 #menu {


### PR DESCRIPTION
## Summary
- Wrap flashcard citations in quotation marks for clearer presentation
- Style citation text with dark grey and source with light grey per design

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b938e49104832b8b85fa14971b27cb