### PR TITLE
Limit game container width

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -520,18 +520,19 @@ button:hover:not(:disabled) {
 .game-list {
   display: grid;
   gap: 1rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(2, 1fr);
 }
 
-@media (min-width: 500px) {
+@media (max-width: 500px) {
   .game-list {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
   }
 }
 
 .game {
   position: relative;
   width: 100%;
+  max-width: 250px;
   height: 120px;
   border-radius: 10px;
   background: linear-gradient(135deg, #4a90e2, #9aa5b1);
@@ -544,6 +545,7 @@ button:hover:not(:disabled) {
   text-align: center;
   cursor: pointer;
   transition: transform 0.2s;
+  justify-self: center;
 }
 
 .game span {


### PR DESCRIPTION
## Summary
- Show two game containers per row by default
- Cap game container width for better layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9398969e0832b9104eeb4ba76f1bd