### PR TITLE
Adjust fonts for reverse flashcards and quizzes

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -84,11 +84,15 @@ function formatCitation(text) {
 function displayWord(word) {
   const work = worksById.get(word.workId);
   const showBtn = document.getElementById('show-btn');
+  const wordEl = document.getElementById('word');
+  const definitionEl = document.getElementById('definition');
   if (mode === 'reverse') {
-    document.getElementById('word').textContent = word.definition;
-    document.getElementById('word').classList.remove('hidden');
-    document.getElementById('definition').textContent = word.word;
-    document.getElementById('definition').classList.add('hidden');
+    wordEl.textContent = word.definition;
+    wordEl.classList.remove('hidden');
+    wordEl.classList.add('small-text');
+    definitionEl.textContent = word.word;
+    definitionEl.classList.add('hidden');
+    definitionEl.classList.add('large-text');
     document.getElementById('citation').innerHTML = formatCitation(word.citation);
     document.getElementById('citation').classList.add('hidden');
     document.getElementById('citation-source').textContent = work
@@ -98,16 +102,18 @@ function displayWord(word) {
     showBtn.dataset.i18n = 'show_word';
     showBtn.textContent = i18next.t('show_word');
   } else {
-    document.getElementById('word').textContent = word.word;
-    document.getElementById('word').classList.remove('hidden');
+    wordEl.textContent = word.word;
+    wordEl.classList.remove('hidden');
+    wordEl.classList.remove('small-text');
+    definitionEl.textContent = word.definition;
+    definitionEl.classList.add('hidden');
+    definitionEl.classList.remove('large-text');
     document.getElementById('citation').innerHTML = formatCitation(word.citation);
     document.getElementById('citation').classList.remove('hidden');
     document.getElementById('citation-source').textContent = work
       ? `${work.title}${work.author ? ' — ' + work.author : ''}`
       : '';
     document.getElementById('citation-source').classList.remove('hidden');
-    document.getElementById('definition').textContent = word.definition;
-    document.getElementById('definition').classList.add('hidden');
     showBtn.dataset.i18n = 'show_definition';
     showBtn.textContent = i18next.t('show_definition');
   }

--- a/public/quiz.js
+++ b/public/quiz.js
@@ -83,7 +83,17 @@ async function loadQuestion() {
       btn.textContent = mode === 'reverse' ? w.word : w.definition;
       btn.disabled = false;
     });
-    document.getElementById('result').textContent = '';
+    const resultEl = document.getElementById('result');
+    if (mode === 'reverse') {
+      questionEl.classList.add('small-text');
+      document.querySelectorAll('#options button').forEach((b) => b.classList.add('large-text'));
+      resultEl.classList.add('large-text');
+    } else {
+      questionEl.classList.remove('small-text');
+      document.querySelectorAll('#options button').forEach((b) => b.classList.remove('large-text'));
+      resultEl.classList.remove('large-text');
+    }
+    resultEl.textContent = '';
     document.getElementById('options').classList.remove('hidden');
     document.getElementById('add-work-btn').classList.add('hidden');
     document.getElementById('quiz-section').classList.remove('hidden');

--- a/public/styles.css
+++ b/public/styles.css
@@ -176,6 +176,26 @@ button:hover:not(:disabled) {
   font-weight: bold;
 }
 
+#word.small-text {
+  font-size: 1.5rem;
+  font-weight: normal;
+}
+
+#definition.large-text {
+  font-size: 3rem;
+  font-weight: bold;
+}
+
+#question.small-text {
+  font-size: 1.5rem;
+}
+
+#options button.large-text,
+#result.large-text {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
 #citation {
   font-style: italic;
   text-align: left;


### PR DESCRIPTION
## Summary
- Reduce definition font size and enlarge answer font for reverse flashcards
- Apply similar font adjustments to reverse quiz questions and options
- Add CSS helpers for small and large text styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b939f11fe8832bbc875376eedd2246