### PR TITLE
Enable game selection for work-specific learning

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -17,6 +17,15 @@
     { id: 'quiz-reverse', nameKey: 'quiz_reverse', link: 'quiz.html?mode=reverse', shape: 'triangle' }
   ];
 
+  const params = new URLSearchParams(window.location.search);
+  const workId = params.get('workId');
+  if (workId) {
+    games.forEach((game) => {
+      const sep = game.link.includes('?') ? '&' : '?';
+      game.link = `${game.link}${sep}workId=${encodeURIComponent(workId)}`;
+    });
+  }
+
   let progressMax = 0;
   let cookies = 0;
 

--- a/public/quiz.js
+++ b/public/quiz.js
@@ -3,6 +3,7 @@ let current = null;
 let correctIndex = 0;
 const params = new URLSearchParams(window.location.search);
 const mode = params.get('mode');
+const workId = params.get('workId');
 let progress = Number(localStorage.getItem('flashcardProgress') || '0');
 let progressMax = 10;
 let cookies = 0;
@@ -63,7 +64,7 @@ function showNoWords() {
 }
 
 async function loadQuestion() {
-  const res = await fetch('/vocab/random?count=4');
+  const res = await fetch(`/vocab/random?count=4${workId ? `&workId=${encodeURIComponent(workId)}` : ''}`);
   if (res.status === 200) {
     const words = await res.json();
     if (words.length < 4) {

--- a/public/work.js
+++ b/public/work.js
@@ -72,7 +72,7 @@ async function loadWork() {
 }
 
 document.getElementById('learn-btn').addEventListener('click', () => {
-  window.location.href = `flashcards.html?workId=${encodeURIComponent(workId)}`;
+  window.location.href = `learn.html?workId=${encodeURIComponent(workId)}`;
 });
 
 document.getElementById('delete-btn').addEventListener('click', async () => {

--- a/src/server.js
+++ b/src/server.js
@@ -235,10 +235,11 @@ app.post('/vocab/extract', async (req, res) => {
 app.get('/vocab/random', (req, res) => {
   const userId = req.session.userId;
   const count = Number(req.query.count) || 1;
+  const { workId } = req.query;
   if (!userId) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  const words = getRandomWords(userId, count);
+  const words = getRandomWords(userId, count, workId);
   if (words.length === 0) return res.status(204).end();
   res.json(words);
 });

--- a/src/vocab.js
+++ b/src/vocab.js
@@ -38,10 +38,13 @@ function getNextWord(userId, workId) {
   return dueWords[0];
 }
 
-function getRandomWords(userId, count) {
+function getRandomWords(userId, count, workId) {
   const store = vocab.get(userId);
   if (!store) return [];
-  const all = Array.from(store.values());
+  let all = Array.from(store.values());
+  if (workId) {
+    all = all.filter((w) => w.workId === workId);
+  }
   if (all.length === 0) return [];
   const shuffled = all.sort(() => Math.random() - 0.5);
   return shuffled.slice(0, count);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -226,4 +226,16 @@ describe('Vocabulary API', () => {
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.body.length, 3);
   });
+
+  it('returns random words for a specific work', async () => {
+    const { agent, userId } = await signupAndLogin('u6@example.com');
+    addWords(userId, [
+      { word: 'alpha', definition: 'first', citation: '', workId: 'w1' },
+      { word: 'beta', definition: 'second', citation: '', workId: 'w1' },
+      { word: 'gamma', definition: 'third', citation: '', workId: 'w2' },
+    ]);
+    const res = await agent.get('/vocab/random').query({ count: 5, workId: 'w1' });
+    assert.strictEqual(res.status, 200);
+    assert(res.body.every((w) => w.workId === 'w1'));
+  });
 });


### PR DESCRIPTION
## Summary
- Redirect "Apprendre" button from a work to the game selection page
- Propagate selected work to chosen game and quiz
- Allow fetching random vocab for a specific work and test it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93b737a90832b8d399c8e3ca5e4fd