### PR TITLE
Keep definition visible on reversed flashcards

### DIFF
--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -166,7 +166,6 @@ async function loadNext() {
 function showDefinition() {
   incrementProgress();
   if (mode === 'reverse') {
-    document.getElementById('word').classList.add('hidden');
     document.getElementById('definition').classList.remove('hidden');
     document.getElementById('citation').classList.remove('hidden');
     document.getElementById('citation-source').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Prevent the definition from being hidden when revealing a word in reverse flashcard mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94ba8fde0832b8da4567e45fca56f