### PR TITLE
Enhance subtitle navigation UI

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -654,6 +654,25 @@ button:hover:not(:disabled) {
   margin-top: 1rem;
 }
 
+#subtitle-hist {
+  position: relative;
+  height: 30px;
+  background-color: var(--color-light);
+  margin-bottom: 0.25rem;
+}
+
+#subtitle-hist .bar {
+  position: absolute;
+  bottom: 0;
+  background-color: var(--color-gray);
+}
+
+#subtitle-hist .axis-label {
+  position: absolute;
+  left: -1.5rem;
+  font-size: 0.6rem;
+}
+
 #subtitle-scale {
   position: relative;
   height: 20px;
@@ -666,6 +685,14 @@ button:hover:not(:disabled) {
   bottom: 0;
   width: 2px;
   background-color: var(--color-gray);
+}
+
+#subtitle-scale .tick .label {
+  position: absolute;
+  top: -1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.6rem;
 }
 
 #subtitle-scale .tick.big {
@@ -687,7 +714,14 @@ button:hover:not(:disabled) {
 #subtitle-word-nav {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 1rem;
+  gap: 0.5rem;
+}
+
+#subtitle-timestamp {
+  color: var(--color-gray);
+}
+
+#subtitle-snippet {
+  font-style: italic;
 }
 

--- a/public/work.html
+++ b/public/work.html
@@ -28,11 +28,14 @@
       <button id="delete-btn" class="btn-danger" data-i18n="delete"></button>
     </div>
     <div id="subtitle-nav" class="hidden">
+      <div id="subtitle-hist"></div>
       <div id="subtitle-scale"></div>
       <div id="subtitle-word-nav">
         <button id="prev-word">&#9664;</button>
-        <span id="subtitle-current-word"></span>
         <button id="next-word">&#9654;</button>
+        <span id="subtitle-current-word"></span>
+        <span id="subtitle-timestamp"></span>
+        <span id="subtitle-snippet"></span>
       </div>
     </div>
   </main>

--- a/public/work.js
+++ b/public/work.js
@@ -13,12 +13,46 @@ function initSubtitleNav(work) {
   const nav = document.getElementById('subtitle-nav');
   nav.classList.remove('hidden');
   const scale = document.getElementById('subtitle-scale');
+  const hist = document.getElementById('subtitle-hist');
   scale.innerHTML = '';
+  hist.innerHTML = '';
   const duration = vocab.length * 5; // fake minutes
+  const bins = Math.ceil(duration / 5);
+  const counts = new Array(bins).fill(0);
+  vocab.forEach((_, i) => {
+    const bin = Math.floor(i);
+    counts[bin]++;
+  });
+  const maxCount = Math.max(...counts, 1);
+  counts.forEach((count, i) => {
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    bar.style.left = `${(i / bins) * 100}%`;
+    bar.style.width = `${100 / bins}%`;
+    bar.style.height = `${(count / maxCount) * 100}%`;
+    hist.appendChild(bar);
+  });
+  const maxLabel = document.createElement('div');
+  maxLabel.className = 'axis-label';
+  maxLabel.style.top = '0';
+  maxLabel.textContent = maxCount;
+  hist.appendChild(maxLabel);
+  const zeroLabel = document.createElement('div');
+  zeroLabel.className = 'axis-label';
+  zeroLabel.style.bottom = '0';
+  zeroLabel.textContent = '0';
+  hist.appendChild(zeroLabel);
+
   for (let m = 0; m <= duration; m += 5) {
     const tick = document.createElement('div');
-    tick.className = 'tick ' + (m % 60 === 0 ? 'big' : 'small');
+    tick.className = 'tick ' + (m % 30 === 0 ? 'big' : 'small');
     tick.style.left = `${(m / duration) * 100}%`;
+    if (m === 5 || (m % 30 === 0 && m !== 0)) {
+      const label = document.createElement('span');
+      label.className = 'label';
+      label.textContent = m === 5 ? '5 min' : `${m} min`;
+      tick.appendChild(label);
+    }
     scale.appendChild(tick);
   }
   const marker = document.createElement('div');
@@ -26,9 +60,16 @@ function initSubtitleNav(work) {
   scale.appendChild(marker);
   let index = 0;
   const wordSpan = document.getElementById('subtitle-current-word');
+  const timeSpan = document.getElementById('subtitle-timestamp');
+  const snippetSpan = document.getElementById('subtitle-snippet');
   function update() {
     const entry = vocab[index];
     wordSpan.textContent = entry ? entry.word : '';
+    snippetSpan.textContent = entry && entry.citation ? entry.citation : '';
+    const minutes = index * 5;
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    timeSpan.textContent = `${h}:${String(m).padStart(2, '0')}`;
     marker.style.left = `${((index * 5) / duration) * 100}%`;
   }
   document.getElementById('prev-word').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Add histogram and tick labels to subtitle navigation for clearer timing and difficulty scale
- Rework word navigator to include timestamp and subtitle snippet with static arrows
- Style subtitle navigation with histogram bars and labeled ticks at 5/30 minute intervals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94c9ec75c832b93120dc191bca5c5