### PR TITLE
feat: keep game buttons in fixed bottom overlay

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="cookies.css" />
   <link href="https://fonts.googleapis.com/css2?family=UnifrakturMaguntia&display=swap" rel="stylesheet" />
 </head>
-<body>
+<body class="with-overlay">
   <header>
     <a href="/"><img src="/images/parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
     <div class="site-text">
@@ -24,17 +24,19 @@
   <main>
     <section id="flashcard-section" class="hidden">
       <div id="flashcard-content">
-      <div id="word"></div>
+        <div id="word"></div>
+        <div id="definition" class="hidden"></div>
+        <div id="citation"></div>
+        <div id="citation-source"></div>
+        <button id="add-work-btn" class="hidden" data-i18n="add_work"></button>
+      </div>
+      <div id="flashcard-buttons" class="overlay-buttons">
         <button id="show-btn" class="btn-main" data-i18n="show_definition"></button>
         <button id="delete-btn" class="btn-danger" data-i18n="delete_known"></button>
         <div id="review-buttons" class="hidden">
           <button data-quality="1" class="btn-main" data-i18n="i_dont_know"></button>
           <button data-quality="4" class="btn-secondary" data-i18n="i_know"></button>
         </div>
-        <div id="definition" class="hidden"></div>
-        <div id="citation"></div>
-        <div id="citation-source"></div>
-        <button id="add-work-btn" class="hidden" data-i18n="add_work"></button>
       </div>
     </section>
   </main>

--- a/public/flashcards.js
+++ b/public/flashcards.js
@@ -121,6 +121,7 @@ function displayWord(word) {
   showBtn.classList.remove('hidden');
   document.getElementById('delete-btn').classList.remove('hidden');
   document.getElementById('add-work-btn').classList.add('hidden');
+  document.getElementById('flashcard-buttons').classList.remove('hidden');
   document.getElementById('flashcard-section').classList.remove('hidden');
 }
 
@@ -156,6 +157,7 @@ async function loadNext() {
       document.getElementById('show-btn').classList.add('hidden');
       document.getElementById('delete-btn').classList.add('hidden');
       document.getElementById('add-work-btn').classList.remove('hidden');
+      document.getElementById('flashcard-buttons').classList.add('hidden');
       document.getElementById('flashcard-section').classList.remove('hidden');
     }
   } else {

--- a/public/quiz.html
+++ b/public/quiz.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="cookies.css" />
   <link href="https://fonts.googleapis.com/css2?family=UnifrakturMaguntia&display=swap" rel="stylesheet" />
 </head>
-<body>
+<body class="with-overlay">
   <header>
     <a href="/"><img src="/images/parrot_grey_no_title.png" alt="Piru logo" class="logo" /></a>
     <div class="site-text">
@@ -24,7 +24,7 @@
   <main>
     <section id="quiz-section" class="hidden">
       <div id="question"></div>
-      <div id="options">
+      <div id="options" class="overlay-buttons">
         <button class="choice btn-main" data-index="0"></button>
         <button class="choice btn-main" data-index="1"></button>
         <button class="choice btn-main" data-index="2"></button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -691,3 +691,33 @@ button:hover:not(:disabled) {
   gap: 1rem;
 }
 
+.with-overlay main {
+  padding-bottom: 6rem;
+}
+
+.overlay-buttons {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background-color: #fff;
+  box-shadow: 0 -2px 8px rgba(34, 31, 31, 0.1);
+  padding: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  z-index: 1000;
+}
+
+#review-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#options.overlay-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- Keep flashcard show/delete/review buttons in a fixed bottom overlay
- Apply the same bottom overlay to quiz choices for all modes
- Add CSS utilities for overlay layout and hide flashcard bar when no words remain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94d3d89b8832bad06ab9d835bf01b