### PR TITLE
Include credentials for quiz fetch requests and handle unauthorized access

### DIFF
--- a/public/quiz.js
+++ b/public/quiz.js
@@ -14,7 +14,7 @@ async function loadProgress() {
     return;
   }
   try {
-    const res = await fetch('/progress');
+    const res = await fetch('/progress', { credentials: 'include' });
     if (res.ok) {
       const data = await res.json();
       progressMax = data.progressMax;
@@ -46,6 +46,7 @@ function incrementProgress() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ progressMax, cookies }),
+      credentials: 'include',
     }).then(() => window.dispatchEvent(new Event('cookiechange')));
   }
   localStorage.setItem('flashcardProgress', progress);
@@ -64,7 +65,11 @@ function showNoWords() {
 }
 
 async function loadQuestion() {
-  const res = await fetch(`/vocab/random?count=4${workId ? `&workId=${encodeURIComponent(workId)}` : ''}`);
+  const res = await fetch(`/vocab/random?count=4${workId ? `&workId=${encodeURIComponent(workId)}` : ''}` , { credentials: 'include' });
+  if (res.status === 401) {
+    window.location.href = '/';
+    return;
+  }
   if (res.status === 200) {
     const words = await res.json();
     if (words.length < 4) {


### PR DESCRIPTION
## Summary
- send credentials with quiz fetch requests to maintain session
- redirect to login when quiz data fetch returns 401

## Testing
- `npm test`
- `curl -i http://localhost:3000/vocab/random?count=4`
- `curl -i -b cookies.txt http://localhost:3000/vocab/random?count=4`


------
https://chatgpt.com/codex/tasks/task_e_68b951cba6f0832bade3899a22b4566f