### PR TITLE
Ensure menu interactive after logging in

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -223,7 +223,8 @@ async function loadWorks() {
   }
 }
 
-function initAuthenticatedState() {
+async function initAuthenticatedState() {
+  await (window.loadMenu?.());
   document.getElementById('auth').classList.add('hidden');
   document.getElementById('menu').classList.remove('hidden');
   document.getElementById('works').classList.remove('hidden');

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,9 +1,9 @@
 (function() {
   function loadMenu() {
     const menu = document.getElementById('menu');
-    if (!menu) return;
+    if (!menu) return Promise.resolve();
 
-    fetch('/menu.html')
+    return fetch('/menu.html')
       .then((res) => res.text())
       .then((html) => {
         menu.innerHTML = html;
@@ -14,7 +14,9 @@
           setupMenu(menu);
         }
       })
-      .catch((err) => console.error('Failed to load menu:', err));
+      .catch((err) => {
+        console.error('Failed to load menu:', err);
+      });
   }
 
   function setupMenu(menu) {
@@ -84,5 +86,6 @@
     menu.classList.remove('hidden');
   }
 
+  window.loadMenu = loadMenu;
   document.addEventListener('DOMContentLoaded', loadMenu);
 })();


### PR DESCRIPTION
## Summary
- Reload menu after authentication so burger button and cookie counter work on the works page
- Expose `loadMenu` globally and await it during authenticated state initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b951530258832b96282b857e18dde2