### PR TITLE
Display user email in burger menu

### DIFF
--- a/public/menu.html
+++ b/public/menu.html
@@ -5,6 +5,7 @@
   <span></span>
 </button>
 <div id="menu-options" class="hidden">
+  <div id="menu-email"></div>
   <a id="works-link" href="/" data-i18n="my_works">My Works</a>
   <a id="learn-link" href="learn.html" data-i18n="learn">Learn</a>
   <a id="stats-link" href="stats.html" data-i18n="view_stats">View Stats</a>

--- a/public/menu.js
+++ b/public/menu.js
@@ -23,6 +23,11 @@
     const toggle = menu.querySelector('#menu-toggle');
     const options = menu.querySelector('#menu-options');
     const header = document.querySelector('header');
+    const emailDisplay = menu.querySelector('#menu-email');
+    const email = localStorage.getItem('email');
+    if (emailDisplay && email) {
+      emailDisplay.textContent = email;
+    }
     if (!toggle || !options) return;
 
     toggle.addEventListener('click', () => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -310,6 +310,11 @@ button:hover:not(:disabled) {
   line-height: 1;
   display: flex;
   align-items: center;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 #menu-email::before {


### PR DESCRIPTION
## Summary
- Always show the current user's email at the top of the burger menu
- Truncate long emails with an ellipsis to keep the menu width consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b982a557e0832b824d4ebb5326017b