### PR TITLE
Use precise subtitle timestamps for vocabulary navigation

### DIFF
--- a/scripts/extract-vocab-cli.js
+++ b/scripts/extract-vocab-cli.js
@@ -27,7 +27,7 @@ async function main() {
 
   try {
     console.error('Extracting vocabulary...');
-    const vocab = await extractVocabulary(text, meta);
+    const { vocab } = await extractVocabulary(text, meta);
     console.log(JSON.stringify(vocab, null, 2));
   } catch (err) {
     console.error('Extraction failed', err.message);

--- a/test/works.test.js
+++ b/test/works.test.js
@@ -228,7 +228,7 @@ describe('Works management', () => {
         citation: 'Second',
       },
     ];
-    const vocab = await extractVocabulary('irrelevant', {});
+    const { vocab } = await extractVocabulary('irrelevant', {});
     assert.strictEqual(vocab.length, 1);
     assert.strictEqual(vocab[0].word, 'Alpha');
     assert.deepStrictEqual(vocab[0].citations, ['First', 'Second']);


### PR DESCRIPTION
## Summary
- parse subtitle files to capture exact timestamps for each vocabulary citation
- expose subtitle duration and timestamps in work data
- update frontend navigation to display histogram and times using real subtitle timestamps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9837214d8832ba3a77f7cb729fb78