### PR TITLE
Improve game selection animation and typography

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -80,11 +80,13 @@
   }
 
   function rainShapes(div, shape) {
-    for (let i = 0; i < 5; i++) {
+    const numDrops = 5;
+    const interval = 100 / (numDrops + 1);
+    for (let i = 0; i < numDrops; i++) {
       const drop = document.createElement('div');
       drop.className = `identifier ${shape} rain`;
-      drop.style.left = `${Math.random() * 100}%`;
-      drop.style.animationDelay = `${Math.random() * 0.5}s`;
+      drop.style.left = `calc(${(i + 1) * interval}% - 10px)`;
+      drop.style.animationDelay = '0s';
       div.appendChild(drop);
       drop.addEventListener('animationend', () => drop.remove());
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.cdnfonts.com/css/gotham');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:ital,wght@1,700&display=swap');
 
 :root {
   --color-yellow: #fdd301;
@@ -75,6 +76,8 @@ main {
 .page-title {
   max-width: 600px;
   margin: 2rem auto;
+  font-family: 'Cinzel', serif;
+  font-style: italic;
 }
 
 .title-row {
@@ -592,11 +595,15 @@ button:hover:not(:disabled) {
   font-weight: bold;
   font-size: 1.3rem;
   transition: color 0.2s, text-shadow 0.2s, background-position 0.6s;
+  font-family: 'Cinzel', serif;
+  font-style: italic;
 }
 
 .game .identifier {
+  --rotate: 0deg;
   margin-top: 0.5rem;
   transition: background 0.2s, border-color 0.2s;
+  transform: rotate(var(--rotate));
 }
 
 .game .identifier.square {
@@ -609,7 +616,7 @@ button:hover:not(:disabled) {
   width: 20px;
   height: 20px;
   background: #fff;
-  transform: rotate(45deg);
+  --rotate: 45deg;
 }
 
 .game .identifier.circle {
@@ -658,7 +665,7 @@ button:hover:not(:disabled) {
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  animation: gold-sweep 1.2s forwards;
+  animation: gold-sweep 1s forwards;
 }
 
 .game.unlocked:hover .identifier {
@@ -675,6 +682,7 @@ button:hover:not(:disabled) {
   left: 0;
   margin-top: 0;
   opacity: 0.8;
+  transform: translate(0, 0) rotate(var(--rotate));
   animation: fall 1s linear forwards;
 }
 
@@ -696,7 +704,7 @@ button:hover:not(:disabled) {
 
 @keyframes fall {
   to {
-    transform: translateY(140px);
+    transform: translate(80px, 140px) rotate(var(--rotate));
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Add evenly spaced diagonal rain animation for game icons.
- Use italic Cinzel font for page title and game names.
- Limit gold sweep effect to 1 second.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b988e99714832bac24b5d886c73514