### PR TITLE
Hide flashcard review buttons until translation reveal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -804,6 +804,10 @@ button:hover:not(:disabled) {
   gap: 0.5rem;
 }
 
+#review-buttons.hidden {
+  display: none;
+}
+
 #options.overlay-buttons {
   display: grid;
   grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
- Ensure flashcard review buttons remain hidden until the translation is shown.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98a1bb898832b9e73670241757b83