### PR TITLE
style: use black classic titles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -76,8 +76,9 @@ main {
 .page-title {
   max-width: 600px;
   margin: 2rem auto;
-  font-family: 'Cinzel', serif;
-  font-style: italic;
+  font-family: 'Gotham', sans-serif;
+  font-style: normal;
+  color: #000;
 }
 
 .title-row {


### PR DESCRIPTION
## Summary
- use Gotham font with normal style for page titles
- set titles to black for consistency with graphic charter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98bd59e40832baf2345273cad5d22