### PR TITLE
feat: display vocabulary progress donut on work thumbnails

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -183,6 +183,25 @@ async function loadWorks() {
         thumb.appendChild(placeholder);
       }
 
+      const total = w.vocabCount || 0;
+      const learned = w.learnedCount || 0;
+      const known = w.knownCount || 0;
+      const learnedPercent = total ? (learned / total) * 100 : 0;
+      const knownPercent = total ? (known / total) * 100 : 0;
+      const progress = total ? Math.round(((learned + known) / total) * 100) : 0;
+
+      const overlay = document.createElement('div');
+      overlay.className = 'work-progress';
+      const kpi = document.createElement('div');
+      kpi.className = 'work-progress-kpi';
+      kpi.textContent = `${progress}%`;
+      overlay.appendChild(kpi);
+      const chart = document.createElement('div');
+      chart.className = 'work-progress-chart';
+      chart.style.background = `conic-gradient(var(--color-yellow) 0 ${learnedPercent}%, var(--color-green) ${learnedPercent}% ${learnedPercent + knownPercent}%, var(--color-gray-light) ${learnedPercent + knownPercent}% 100%)`;
+      overlay.appendChild(chart);
+      thumb.appendChild(overlay);
+
       item.appendChild(thumb);
 
       const caption = document.createElement('div');

--- a/public/styles.css
+++ b/public/styles.css
@@ -9,6 +9,8 @@
   --color-light: #edf2f2;
   --color-gray: #6d7070;
   --color-dark: #221f1f;
+  --color-green: #22c55e;
+  --color-gray-light: #e5e7eb;
 }
 
 body {
@@ -469,6 +471,48 @@ button:hover:not(:disabled) {
 
 .work-thumb {
   position: relative;
+}
+
+.work-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.8);
+  pointer-events: none;
+}
+
+.work-progress-kpi {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.work-progress-chart {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  position: relative;
+}
+
+.work-progress-chart::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 60%;
+  height: 60%;
+  background: var(--color-light);
+  border-radius: 50%;
+}
+
+.work-thumb:hover .work-progress {
+  display: flex;
 }
 
 .learn-btn,

--- a/src/works.js
+++ b/src/works.js
@@ -402,7 +402,8 @@ function listWorks(userId) {
         thumbnail,
         subtitleDuration,
       }) => {
-        const { learned } = getWorkStats(userId, id);
+        const { total, learned } = getWorkStats(userId, id);
+        const known = vocab.length - total;
         return {
           id,
           title,
@@ -414,6 +415,7 @@ function listWorks(userId) {
           subtitleDuration,
           vocabCount: vocab.length,
           learnedCount: learned,
+          knownCount: known,
         };
       }
     );
@@ -431,7 +433,8 @@ function listAllWorks() {
       thumbnail,
       subtitleDuration,
     }) => {
-      const { learned } = getWorkStats(userId, id);
+      const { total, learned } = getWorkStats(userId, id);
+      const known = vocab.length - total;
       return {
         id,
         userId,
@@ -443,6 +446,7 @@ function listAllWorks() {
         subtitleDuration,
         vocabCount: vocab.length,
         learnedCount: learned,
+        knownCount: known,
       };
     }
   );


### PR DESCRIPTION
## Summary
- track known vocab count for each work in API responses
- show donut chart and KPI over thumbnails to visualize vocab progress
- style progress overlay and add green/gray color variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98cb42ad8832b927ff0ca6f315f06