### PR TITLE
Ensure subtitle navigation works with case-insensitive citations

### DIFF
--- a/src/works.js
+++ b/src/works.js
@@ -269,12 +269,15 @@ async function extractVocabulary(text, meta = {}) {
           : [];
         const ts = [];
         for (const cit of cits) {
-          const match = batchSubs.find(
-            (sub) =>
-              sub.text === cit ||
-              sub.text.includes(cit) ||
-              cit.includes(sub.text)
-          );
+          const lc = String(cit).toLowerCase();
+          const match = batchSubs.find((sub) => {
+            const subText = sub.text.toLowerCase();
+            return (
+              subText === lc ||
+              subText.includes(lc) ||
+              lc.includes(subText)
+            );
+          });
           if (match) {
             ts.push(match.time);
           }

--- a/test/works.test.js
+++ b/test/works.test.js
@@ -190,6 +190,33 @@ describe('Works management', () => {
     ]);
   });
 
+  it('matches subtitle citations case-insensitively', async () => {
+    chatgpt.extractVocabularyWithLLM = async (chunk) => {
+      if (chunk.includes('Hedwig')) {
+        return [
+          {
+            id: crypto.randomUUID(),
+            word: 'hedwig',
+            definition: '',
+            citation:
+              "i can't let you out, hedwig. i'm not allowed to use magic outside of school.",
+          },
+        ];
+      }
+      return [];
+    };
+    const work = await addWork(
+      'caseSubUser',
+      'Harry Potter and the Chamber of Secrets',
+      '',
+      '',
+      'movie'
+    );
+    const entry = work.vocab.find((v) => v.word === 'hedwig');
+    assert.ok(entry);
+    assert.strictEqual(typeof entry.timestamp, 'number');
+  });
+
   it('merges vocabulary entries with different casing', async () => {
     chatgpt.extractVocabularyWithLLM = async () => [
       {


### PR DESCRIPTION
## Summary
- Match subtitle citations case-insensitively when deriving timestamps
- Add regression test ensuring lowercase citations still receive timestamps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98d2c0840832b8108c6b9980682b5