### PR TITLE
Refine vocabulary game visuals

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -80,20 +80,30 @@
   }
 
   function rainShapes(div, shape) {
-    const numDrops = 20;
-    for (let i = 0; i < numDrops; i++) {
-      const left = Math.random() * 100;
-      const drop = document.createElement('div');
-      drop.className = `identifier ${shape} rain`;
-      drop.style.left = `calc(${left}% - 10px)`;
-      div.appendChild(drop);
-      drop.addEventListener('animationend', () => drop.remove());
+    const cols = 5;
+    const rows = 4;
+    const widthStep = 100 / cols;
+    const heightStep = 30;
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const leftPercent = c * widthStep + widthStep / 2;
+        const topOffset = -20 - r * heightStep;
 
-      const line = document.createElement('div');
-      line.className = 'rain-line';
-      line.style.left = `calc(${left}% - 1px)`;
-      div.appendChild(line);
-      line.addEventListener('animationend', () => line.remove());
+        const drop = document.createElement('div');
+        drop.className = `identifier ${shape} rain`;
+        drop.style.left = `calc(${leftPercent}% - 10px)`;
+        drop.style.top = `${topOffset}px`;
+        div.appendChild(drop);
+        drop.addEventListener('animationend', () => drop.remove());
+
+        const line = document.createElement('div');
+        line.className = 'rain-line';
+        line.style.left = `calc(${leftPercent}% - 1px)`;
+        line.style.top = `${topOffset}px`;
+        line.style.setProperty('--rotate', '-30deg');
+        div.appendChild(line);
+        line.addEventListener('animationend', () => line.remove());
+      }
     }
   }
 
@@ -113,10 +123,6 @@
       span.setAttribute('data-i18n', game.nameKey);
       span.textContent = i18next.t(game.nameKey);
       div.appendChild(span);
-
-      const shape = document.createElement('div');
-      shape.className = `identifier ${game.shape || ''}`;
-      div.appendChild(shape);
 
       if (isUnlocked) {
         div.classList.add('unlocked');

--- a/public/styles.css
+++ b/public/styles.css
@@ -596,11 +596,13 @@ button:hover:not(:disabled) {
   pointer-events: none;
   font-weight: bold;
   font-size: 1.3rem;
-  transition: color 0.2s, text-shadow 0.2s, background-position 0.6s;
+  transition: color 0.2s, text-shadow 0.2s, background-position 0.05s;
   font-family: 'Press Start 2P', cursive;
   text-transform: uppercase;
   position: relative;
   z-index: 2;
+  -webkit-text-stroke: 1px #000;
+  text-stroke: 1px #000;
 }
 
 .game .identifier {
@@ -671,7 +673,7 @@ button:hover:not(:disabled) {
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  animation: gold-sweep 1s forwards;
+  animation: gold-sweep 0.05s forwards;
 }
 
 .game.unlocked:hover .identifier {
@@ -711,7 +713,7 @@ button:hover:not(:disabled) {
   height: 40px;
   background: #000;
   opacity: 0.8;
-  transform: translate(0, 0) rotate(-30deg);
+  transform: translate(0, 0) rotate(var(--rotate));
   animation: fall 0.5s linear forwards;
   z-index: 0;
 }
@@ -730,7 +732,7 @@ button:hover:not(:disabled) {
 
 @keyframes fall {
   to {
-    transform: translate(80px, 140px) rotate(var(--rotate));
+    transform: translateY(160px) rotate(var(--rotate));
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Speed up gold text sweep and outline letters in black
- Remove static shape icons from vocabulary game cards
- Rain geometric shapes in evenly spaced grid with matching lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98e0600e0832bad32746a0913cc98