### PR TITLE
Remove unnecessary Cinzel font import

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1,5 +1,4 @@
 @import url('https://fonts.cdnfonts.com/css/gotham');
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:ital,wght@1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 
 :root {


### PR DESCRIPTION
## Summary
- stop importing Cinzel font from Google Fonts to avoid failing request

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98e991a64832bbb3b6215e44a8ef8