### PR TITLE
Make donut chart center transparent on thumbnails

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -499,18 +499,8 @@ button:hover:not(:disabled) {
   height: 50px;
   border-radius: 50%;
   position: relative;
-}
-
-.work-progress-chart::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 60%;
-  height: 60%;
-  background: var(--color-light);
-  border-radius: 50%;
+  -webkit-mask: radial-gradient(farthest-side, transparent 60%, #000 60%);
+  mask: radial-gradient(farthest-side, transparent 60%, #000 60%);
 }
 
 .work-thumb:hover .work-progress {


### PR DESCRIPTION
## Summary
- ensure work progress donut chart uses masking to show transparent center on thumbnails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98ecad584832ba839977ebd4c0708