### PR TITLE
Show progress percentage next to difficulty badge

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -163,11 +163,28 @@ async function loadWorks() {
       const item = document.createElement('div');
       item.className = 'work-item';
 
+      const total = w.vocabCount || 0;
+      const learned = w.learnedCount || 0;
+      const known = w.knownCount || 0;
+      const learnedPercent = total ? (learned / total) * 100 : 0;
+      const knownPercent = total ? (known / total) * 100 : 0;
+      const progress = total ? Math.round(((learned + known) / total) * 100) : 0;
+
       const stats = getDifficulty(w.vocabCount || (w.vocab ? w.vocab.length : 0));
+      const badgeWrapper = document.createElement('div');
+      badgeWrapper.className = 'difficulty-badge-wrapper';
+
       const badge = document.createElement('div');
       badge.className = `difficulty-badge badge-${stats.class}`;
       badge.textContent = stats.label;
-      item.appendChild(badge);
+      badgeWrapper.appendChild(badge);
+
+      const progressText = document.createElement('div');
+      progressText.className = 'difficulty-progress';
+      progressText.textContent = `${progress}%`;
+      badgeWrapper.appendChild(progressText);
+
+      item.appendChild(badgeWrapper);
 
       const thumb = document.createElement('div');
       thumb.className = 'work-thumb';
@@ -182,13 +199,6 @@ async function loadWorks() {
         placeholder.textContent = i18next.t(w.type);
         thumb.appendChild(placeholder);
       }
-
-      const total = w.vocabCount || 0;
-      const learned = w.learnedCount || 0;
-      const known = w.knownCount || 0;
-      const learnedPercent = total ? (learned / total) * 100 : 0;
-      const knownPercent = total ? (known / total) * 100 : 0;
-      const progress = total ? Math.round(((learned + known) / total) * 100) : 0;
 
       const overlay = document.createElement('div');
       overlay.className = 'work-progress';

--- a/public/styles.css
+++ b/public/styles.css
@@ -562,7 +562,18 @@ button:hover:not(:disabled) {
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   font-size: 0.6rem;
+}
+
+.difficulty-badge-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
   margin-bottom: 0.25rem;
+}
+
+.difficulty-progress {
+  font-size: 0.6rem;
 }
 
 .badge-easy {


### PR DESCRIPTION
## Summary
- Display combined learned and known percentage beside difficulty badge for each work
- Style badge area to align progress percentage with difficulty label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98efc4f84832b81b0dc894b7698cc