### PR TITLE
Add oblique colored rain to vocabulary game hover

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -5,16 +5,30 @@
       nameKey: 'flashcard_classic',
       link: 'flashcards.html',
       unlocked: true,
-      shape: 'square'
+      shape: 'square',
+      color: 'var(--color-yellow)'
     },
     {
       id: 'flashcard-reverse',
       nameKey: 'flashcard_reverse',
       link: 'flashcards.html?mode=reverse',
-      shape: 'diamond'
+      shape: 'diamond',
+      color: 'var(--color-blue)'
     },
-    { id: 'quiz', nameKey: 'quiz', link: 'quiz.html', shape: 'circle' },
-    { id: 'quiz-reverse', nameKey: 'quiz_reverse', link: 'quiz.html?mode=reverse', shape: 'triangle' }
+    {
+      id: 'quiz',
+      nameKey: 'quiz',
+      link: 'quiz.html',
+      shape: 'circle',
+      color: 'var(--color-pink)'
+    },
+    {
+      id: 'quiz-reverse',
+      nameKey: 'quiz_reverse',
+      link: 'quiz.html?mode=reverse',
+      shape: 'triangle',
+      color: 'var(--color-green)'
+    }
   ];
 
   const params = new URLSearchParams(window.location.search);
@@ -80,10 +94,12 @@
   }
 
   function rainShapes(div, shape) {
-    const cols = 5;
+    const cols = 10;
     const rows = 4;
     const widthStep = 100 / cols;
     const heightStep = 30;
+    const angle = 30;
+    const dx = 160 * Math.tan((angle * Math.PI) / 180);
     for (let r = 0; r < rows; r++) {
       for (let c = 0; c < cols; c++) {
         const leftPercent = c * widthStep + widthStep / 2;
@@ -93,6 +109,8 @@
         drop.className = `identifier ${shape} rain`;
         drop.style.left = `calc(${leftPercent}% - 10px)`;
         drop.style.top = `${topOffset}px`;
+        drop.style.setProperty('--rotate', `-${angle}deg`);
+        drop.style.setProperty('--dx', `${dx}px`);
         div.appendChild(drop);
         drop.addEventListener('animationend', () => drop.remove());
 
@@ -100,7 +118,8 @@
         line.className = 'rain-line';
         line.style.left = `calc(${leftPercent}% - 1px)`;
         line.style.top = `${topOffset}px`;
-        line.style.setProperty('--rotate', '-30deg');
+        line.style.setProperty('--rotate', `-${angle}deg`);
+        line.style.setProperty('--dx', `${dx}px`);
         div.appendChild(line);
         line.addEventListener('animationend', () => line.remove());
       }
@@ -118,6 +137,11 @@
       const div = document.createElement('div');
       div.className = 'game';
       div.id = game.id;
+      div.style.setProperty('--hover-color', game.color);
+
+      const icon = document.createElement('div');
+      icon.className = `identifier ${game.shape}`;
+      div.appendChild(icon);
 
       const span = document.createElement('span');
       span.setAttribute('data-i18n', game.nameKey);

--- a/public/styles.css
+++ b/public/styles.css
@@ -712,7 +712,7 @@ button:hover:not(:disabled) {
 }
 
 .game.unlocked:hover span {
-  background: linear-gradient(90deg, #fff 0%, #ffd700 50%, #fff 100%);
+  background: linear-gradient(90deg, #fff 0%, var(--hover-color) 50%, #fff 100%);
   background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
@@ -721,11 +721,16 @@ button:hover:not(:disabled) {
 }
 
 .game.unlocked:hover .identifier {
-  background: #ffd700;
+  background: var(--hover-color);
+  border-color: var(--hover-color);
 }
 
 .game.unlocked:hover .identifier.triangle {
-  border-bottom-color: #ffd700;
+  border-bottom-color: var(--hover-color);
+}
+
+.game.unlocked:hover .rain-line {
+  background: var(--hover-color);
 }
 
 .game .identifier.rain {
@@ -734,6 +739,7 @@ button:hover:not(:disabled) {
   left: 0;
   margin-top: 0;
   opacity: 0.8;
+  --dx: 0px;
   transform: translate(0, 0) rotate(var(--rotate));
   animation: fall 0.5s linear forwards;
   z-index: 0;
@@ -754,9 +760,10 @@ button:hover:not(:disabled) {
   position: absolute;
   top: -20px;
   width: 2px;
-  height: 40px;
+  height: 20px;
   background: #000;
   opacity: 0.8;
+  --dx: 0px;
   transform: translate(0, 0) rotate(var(--rotate));
   animation: fall 0.5s linear forwards;
   z-index: 0;
@@ -776,7 +783,7 @@ button:hover:not(:disabled) {
 
 @keyframes fall {
   to {
-    transform: translateY(160px) rotate(var(--rotate));
+    transform: translate(var(--dx), 160px) rotate(var(--rotate));
     opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Color-code each vocabulary game and add matching identifier icons
- Make hover rain oblique with double shapes and half-length drops
- Support diagonal animation with per-game colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9cea87dcc832b9f8ebd1cf3caf753