### PR TITLE
Handle string timestamps in subtitle navigation

### DIFF
--- a/public/work.js
+++ b/public/work.js
@@ -9,7 +9,8 @@ if (!workId) {
 function initSubtitleNav(work) {
   if (work.type !== 'movie' && work.type !== 'series') return;
   const vocab = (work.vocab || [])
-    .filter((v) => typeof v.timestamp === 'number')
+    .map((v) => ({ ...v, timestamp: Number(v.timestamp) }))
+    .filter((v) => !Number.isNaN(v.timestamp))
     .sort((a, b) => a.timestamp - b.timestamp);
   if (!vocab.length) return;
   const nav = document.getElementById('subtitle-nav');


### PR DESCRIPTION
## Summary
- Normalize vocabulary timestamps so subtitle navigation works even when provided as strings

## Testing
- `npm test`
- `npm run test-subtitle-vocab` *(fails: OPENAI_API_KEY not set, skipping)*

------
https://chatgpt.com/codex/tasks/task_e_68b98f269a34832ba3b319bb00689f1e