### PR TITLE
Remove game card icon and enforce triangle rain for reverse quiz

### DIFF
--- a/public/learn.js
+++ b/public/learn.js
@@ -143,10 +143,6 @@
       div.id = game.id;
       div.style.setProperty('--hover-color', game.color);
 
-      const icon = document.createElement('div');
-      icon.className = `identifier ${game.shape}`;
-      div.appendChild(icon);
-
       const span = document.createElement('span');
       span.setAttribute('data-i18n', game.nameKey);
       span.textContent = i18next.t(game.nameKey);
@@ -176,7 +172,8 @@
 
       div.addEventListener('mouseenter', () => {
         if (isUnlocked) {
-          rainShapes(div, game.shape || '');
+          const shape = game.id === 'quiz-reverse' ? 'triangle' : (game.shape || '');
+          rainShapes(div, shape);
         }
       });
 


### PR DESCRIPTION
## Summary
- Remove static icon from game cards so names appear without a shape above
- Ensure reverse quiz always rains triangle shapes when hovered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baaa9569bc832ba9acbc61522176fa