### PR TITLE
Display remaining difficult words on media hover

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -169,6 +169,7 @@ async function loadWorks() {
       const learnedPercent = total ? (learned / total) * 100 : 0;
       const knownPercent = total ? (known / total) * 100 : 0;
       const progress = total ? Math.round(((learned + known) / total) * 100) : 0;
+      const remaining = Math.max(total - learned - known, 0);
 
       const stats = getDifficulty(w.vocabCount || (w.vocab ? w.vocab.length : 0));
       const badgeWrapper = document.createElement('div');
@@ -204,7 +205,8 @@ async function loadWorks() {
       overlay.className = 'work-progress';
       const kpi = document.createElement('div');
       kpi.className = 'work-progress-kpi';
-      kpi.textContent = `${progress}%`;
+      const remainingLabel = remaining > 99 ? i18next.t('remaining_over_99') : i18next.t('remaining_words', { count: remaining });
+      kpi.textContent = remainingLabel;
       overlay.appendChild(kpi);
       const chart = document.createElement('div');
       chart.className = 'work-progress-chart';

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -69,7 +69,10 @@ const i18nResources = {
       cookie_count_plural: '{{count}} cookies',
       unlock_question: 'Unlock? {{count}} cookie',
       unlock_question_plural: 'Unlock? {{count}} cookies',
-      play: 'Play'
+      play: 'Play',
+      remaining_words: '{{count}} remaining',
+      remaining_words_plural: '{{count}} remaining',
+      remaining_over_99: '99+ remaining'
     }
   },
   fr: {
@@ -141,7 +144,10 @@ const i18nResources = {
       cookie_count_plural: '{{count}} cookies',
       unlock_question: 'Débloquer ? {{count}} cookie',
       unlock_question_plural: 'Débloquer ? {{count}} cookies',
-      play: 'Jouer'
+      play: 'Jouer',
+      remaining_words: '{{count}} restant',
+      remaining_words_plural: '{{count}} restants',
+      remaining_over_99: '99+ restants'
     }
   },
   es: {
@@ -213,7 +219,10 @@ const i18nResources = {
       cookie_count_plural: '{{count}} galletas',
       unlock_question: '¿Desbloquear? {{count}} galleta',
       unlock_question_plural: '¿Desbloquear? {{count}} galletas',
-      play: 'Jugar'
+      play: 'Jugar',
+      remaining_words: '{{count}} restante',
+      remaining_words_plural: '{{count}} restantes',
+      remaining_over_99: '99+ restantes'
     }
   },
   it: {
@@ -285,7 +294,10 @@ const i18nResources = {
       cookie_count_plural: '{{count}} biscotti',
       unlock_question: 'Sbloccare? {{count}} biscotto',
       unlock_question_plural: 'Sbloccare? {{count}} biscotti',
-      play: 'Gioca'
+      play: 'Gioca',
+      remaining_words: '{{count}} rimanente',
+      remaining_words_plural: '{{count}} rimanenti',
+      remaining_over_99: '99+ rimanenti'
     }
   },
   de: {
@@ -357,7 +369,10 @@ const i18nResources = {
       cookie_count_plural: '{{count}} Kekse',
       unlock_question: 'Freischalten? {{count}} Keks',
       unlock_question_plural: 'Freischalten? {{count}} Kekse',
-      play: 'Spielen'
+      play: 'Spielen',
+      remaining_words: '{{count}} übrig',
+      remaining_words_plural: '{{count}} übrig',
+      remaining_over_99: '99+ übrig'
     }
   }
 };


### PR DESCRIPTION
## Summary
- show remaining difficult words instead of percentage when hovering over a work
- add i18n strings for remaining-word counts in all languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baad838514832bac4c9b0d56ec6323