### PR TITLE
Fix reverse quiz rain shapes

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -752,7 +752,9 @@ button:hover:not(:disabled) {
 }
 
 .game .identifier.rain.triangle {
-  border-bottom-color: #fff;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid #fff;
   filter: drop-shadow(0 0 0 #000);
 }
 


### PR DESCRIPTION
## Summary
- Ensure reverse quiz rains triangles by defining proper border-based triangle styling in CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baaf295de8832bac4b00f35be96604