### PR TITLE
feat: prototype QCM interface with flashcard layout

### DIFF
--- a/public/quiz.html
+++ b/public/quiz.html
@@ -22,16 +22,18 @@
     <div id="progress-container"><div id="progress-bar"></div><div id="progress-cookie">🍪</div></div>
   </div>
   <main>
-    <section id="quiz-section" class="hidden">
-      <div id="question"></div>
-      <div id="options" class="overlay-buttons">
+    <section id="flashcard-section" class="hidden">
+      <div id="flashcard-content">
+        <div id="word"></div>
+        <div id="definition" class="hidden"></div>
+        <button id="add-work-btn" class="hidden" data-i18n="add_work"></button>
+      </div>
+      <div id="quiz-buttons" class="overlay-buttons">
         <button class="choice btn-main" data-index="0"></button>
         <button class="choice btn-main" data-index="1"></button>
         <button class="choice btn-main" data-index="2"></button>
         <button class="choice btn-main" data-index="3"></button>
       </div>
-      <div id="result"></div>
-      <button id="add-work-btn" class="hidden" data-i18n="add_work"></button>
     </section>
   </main>
   <script src="/lib/i18next/umd/i18next.min.js"></script>

--- a/public/quiz.js
+++ b/public/quiz.js
@@ -58,10 +58,11 @@ updateProgress();
 window.addEventListener('cookiechange', loadProgress);
 
 function showNoWords() {
-  document.getElementById('question').textContent = i18next.t('no_words');
-  document.getElementById('options').classList.add('hidden');
+  const wordEl = document.getElementById('word');
+  wordEl.textContent = i18next.t('no_words');
+  document.getElementById('quiz-buttons').classList.add('hidden');
   document.getElementById('add-work-btn').classList.remove('hidden');
-  document.getElementById('quiz-section').classList.remove('hidden');
+  document.getElementById('flashcard-section').classList.remove('hidden');
 }
 
 async function loadQuestion() {
@@ -78,31 +79,32 @@ async function loadQuestion() {
     }
     correctIndex = Math.floor(Math.random() * words.length);
     current = words[correctIndex];
-    const questionEl = document.getElementById('question');
+    const wordEl = document.getElementById('word');
+    const defEl = document.getElementById('definition');
     if (mode === 'reverse') {
-      questionEl.textContent = current.definition;
+      wordEl.textContent = current.definition;
+      wordEl.classList.add('small-text');
+      defEl.classList.add('large-text');
     } else {
-      questionEl.textContent = current.word;
+      wordEl.textContent = current.word;
+      wordEl.classList.remove('small-text');
+      defEl.classList.remove('large-text');
     }
+    defEl.textContent = '';
+    defEl.classList.add('hidden');
     words.forEach((w, i) => {
-      const btn = document.querySelector(`#options button[data-index="${i}"]`);
+      const btn = document.querySelector(`#quiz-buttons button[data-index="${i}"]`);
       btn.textContent = mode === 'reverse' ? w.word : w.definition;
       btn.disabled = false;
+      if (mode === 'reverse') {
+        btn.classList.add('large-text');
+      } else {
+        btn.classList.remove('large-text');
+      }
     });
-    const resultEl = document.getElementById('result');
-    if (mode === 'reverse') {
-      questionEl.classList.add('small-text');
-      document.querySelectorAll('#options button').forEach((b) => b.classList.add('large-text'));
-      resultEl.classList.add('large-text');
-    } else {
-      questionEl.classList.remove('small-text');
-      document.querySelectorAll('#options button').forEach((b) => b.classList.remove('large-text'));
-      resultEl.classList.remove('large-text');
-    }
-    resultEl.textContent = '';
-    document.getElementById('options').classList.remove('hidden');
+    document.getElementById('quiz-buttons').classList.remove('hidden');
     document.getElementById('add-work-btn').classList.add('hidden');
-    document.getElementById('quiz-section').classList.remove('hidden');
+    document.getElementById('flashcard-section').classList.remove('hidden');
   } else if (res.status === 204) {
     showNoWords();
   } else {
@@ -111,18 +113,19 @@ async function loadQuestion() {
 }
 
 function selectOption(idx) {
-  const result = document.getElementById('result');
+  const defEl = document.getElementById('definition');
   if (idx === correctIndex) {
-    result.textContent = '✓';
+    defEl.textContent = '✓';
     incrementProgress();
   } else {
-    result.textContent = mode === 'reverse' ? current.word : current.definition;
+    defEl.textContent = mode === 'reverse' ? current.word : current.definition;
   }
-  document.querySelectorAll('#options button').forEach((b) => (b.disabled = true));
+  defEl.classList.remove('hidden');
+  document.querySelectorAll('#quiz-buttons button').forEach((b) => (b.disabled = true));
   setTimeout(loadQuestion, 1000);
 }
 
-document.querySelectorAll('#options button').forEach((btn) => {
+document.querySelectorAll('#quiz-buttons button').forEach((btn) => {
   btn.addEventListener('click', () => selectOption(Number(btn.dataset.index)));
 });
 


### PR DESCRIPTION
## Summary
- refactor quiz page to reuse flashcard layout
- add four choice buttons for QCM modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab53cf460832b96214b1b37a342ea