### PR TITLE
feat: add word revision counter

### DIFF
--- a/public/menu.html
+++ b/public/menu.html
@@ -1,3 +1,4 @@
+<span id="word-count" class="word-counter">📘<span id="words-remaining" class="badge remaining">0</span><span id="words-learned" class="badge learned">0</span></span>
 <span id="cookie-count" class="cookie-counter">🍪0</span>
 <button id="menu-toggle" class="burger-button" aria-label="Menu" aria-expanded="false">
   <span></span>

--- a/public/menu.js
+++ b/public/menu.js
@@ -84,8 +84,41 @@
         alert('Révise ton vocabulaire pour gagner des cookies !');
       });
     }
+    const wordDisplay = menu.querySelector('#word-count');
+    const remainingBadge = menu.querySelector('#words-remaining');
+    const learnedBadge = menu.querySelector('#words-learned');
+    async function renderWords() {
+      if (!wordDisplay) return;
+      if (!localStorage.getItem('email')) {
+        wordDisplay.classList.add('hidden');
+        return;
+      }
+      try {
+        const res = await fetch('/stats/overview');
+        if (res.ok) {
+          const data = await res.json();
+          const remaining = Math.max(data.totalWords - data.masteredWords, 0);
+          if (remainingBadge) remainingBadge.textContent = remaining;
+          if (learnedBadge) learnedBadge.textContent = data.masteredWords;
+          wordDisplay.classList.remove('hidden');
+        } else {
+          wordDisplay.classList.add('hidden');
+        }
+      } catch {
+        wordDisplay.classList.add('hidden');
+      }
+    }
+    if (wordDisplay) {
+      wordDisplay.addEventListener('click', () => {
+        window.location.href = 'learn.html';
+      });
+    }
     renderCookies();
-    window.addEventListener('cookiechange', renderCookies);
+    renderWords();
+    window.addEventListener('cookiechange', () => {
+      renderCookies();
+      renderWords();
+    });
 
     // Show menu by default; server-side session determines access.
     menu.classList.remove('hidden');

--- a/public/styles.css
+++ b/public/styles.css
@@ -223,6 +223,33 @@ button:hover:not(:disabled) {
   z-index: 2000;
 }
 
+.word-counter {
+  position: relative;
+  margin-right: 1rem;
+  font-size: 1.25rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.word-counter .badge {
+  position: absolute;
+  top: -0.5rem;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 9999px;
+  color: #fff;
+}
+
+.word-counter .badge.remaining {
+  right: -0.5rem;
+  background: var(--color-pink);
+}
+
+.word-counter .badge.learned {
+  left: -0.5rem;
+  background: var(--color-green);
+}
+
 .cookie-counter {
   margin-right: 2rem;
   font-size: 1.25rem;


### PR DESCRIPTION
## Summary
- display word revision counter with remaining and learned badges
- fetch vocabulary stats and update badges beside cookie counter
- style new counter with red/green notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bab5b87ed4832b87529efdbbf85e02