### PR TITLE
feat: add border to raining triangles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -748,10 +748,12 @@ button:hover:not(:disabled) {
 }
 
 .game .identifier.rain.triangle {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 20px solid var(--hover-color);
-  filter: drop-shadow(0 0 0 #000);
+  width: 20px;
+  height: 20px;
+  background: var(--hover-color);
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  border: 2px solid #000;
+  box-sizing: border-box;
 }
 
 .game .rain-line {


### PR DESCRIPTION
## Summary
- display raining triangles with black borders in reverse quiz

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bab642305c832ba0456483661f77e9