### PR TITLE
Expand flashcard button width

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -811,9 +811,14 @@ button:hover:not(:disabled) {
   z-index: 1000;
 }
 
+#flashcard-buttons button {
+  flex: 1 1 45%;
+}
+
 #review-buttons {
   display: flex;
   gap: 0.5rem;
+  width: 100%;
 }
 
 #review-buttons.hidden {


### PR DESCRIPTION
## Summary
- Make flashcard buttons expand to roughly half the screen width to minimize background whitespace

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd883e9b1c832b8e8c6eb5312543e7