### PR TITLE
fix flashcard delete button overflow

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -814,10 +814,12 @@ button:hover:not(:disabled) {
   gap: 0.5rem;
   flex-wrap: wrap;
   z-index: 1000;
+  box-sizing: border-box;
 }
 
 #flashcard-buttons button {
   flex: 1 1 45%;
+  box-sizing: border-box;
 }
 
 #review-buttons {


### PR DESCRIPTION
## Summary
- prevent flashcard action buttons from overflowing by including padding in width calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda2739004832bae03059c01f1411b