### PR TITLE
Adjust flashcard and quiz container height

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -160,17 +160,13 @@ button:hover:not(:disabled) {
   height: 100px;
 }
 
-#flashcard-section {
+#flashcard-section,
+#quiz-section {
   text-align: center;
   margin-top: 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
 }
 
 #flashcard-content {
-  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- Remove fixed flex layout from flashcard and quiz sections so their height fits content
- Clean up flashcard content styling to avoid excessive vertical space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda2b10498832b9acdd8c784197a0b